### PR TITLE
Fix 'multiple values for argument' error in Flask client.

### DIFF
--- a/authlib/flask/client/oauth.py
+++ b/authlib/flask/client/oauth.py
@@ -72,9 +72,12 @@ class OAuth(object):
                 v = self.app.config.get(conf_key, None)
                 kwargs[k] = v
 
+        fetch_token = kwargs.pop('fetch_token', None) or self.fetch_token
+        update_token = kwargs.pop('update_token', None) or self.update_token
+
         client = RemoteApp(
-            name, self.cache, self.fetch_token,
-            self.update_token, **kwargs
+            name, self.cache, fetch_token,
+            update_token, **kwargs
         )
         if compliance_fix:
             client.compliance_fix = compliance_fix


### PR DESCRIPTION
Kwarg passed to `register()` takes precedence over the one defined in
the constructor or `init_app()`

Fixes #9

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.

  