### PR TITLE
fix documents regarding OAuth.register

### DIFF
--- a/docs/client/frameworks.rst
+++ b/docs/client/frameworks.rst
@@ -38,18 +38,18 @@ Configuration
 To register a remote application on OAuth registry, using the
 :meth:`~OAuth.register` method::
 
-    oauth.register('twitter', {
-        'client_key': 'Twitter Consumer Key',
-        'client_secret': 'Twitter Consumer Secret',
-        'request_token_url': 'https://api.twitter.com/oauth/request_token',
-        'request_token_params': None,
-        'access_token_url': 'https://api.twitter.com/oauth/access_token',
-        'access_token_params': None,
-        'refresh_token_url': None,
-        'authorize_url': 'https://api.twitter.com/oauth/authenticate',
-        'api_base_url': 'https://api.twitter.com/1.1/',
-        'client_kwargs': None,
-    })
+    oauth.register('twitter',
+        client_key='Twitter Consumer Key',
+        client_secret='Twitter Consumer Secret',
+        request_token_url='https://api.twitter.com/oauth/request_token',
+        request_token_params=None,
+        access_token_url='https://api.twitter.com/oauth/access_token',
+        access_token_params=None,
+        refresh_token_url=None,
+        authorize_url='https://api.twitter.com/oauth/authenticate',
+        api_base_url='https://api.twitter.com/1.1/',
+        client_kwargs=None,
+    )
 
 The first parameter in ``register`` method is the **name** of the remote
 application. You can access the remote application with::
@@ -66,7 +66,7 @@ TWITTER_CLIENT_SECRET      Twitter Consumer Secret
 TWITTER_REQUEST_TOKEN_URL  URL to fetch OAuth request token
 ========================== ================================
 
-If you register your remote app as ``oauth.register('example', {...})``, the
+If you register your remote app as ``oauth.register('example', ...)``, the
 config key would look like:
 
 ========================== ===============================
@@ -332,10 +332,10 @@ requests session as in :ref:`compliance_fix_mixed`::
 
 When :meth:`OAuth.register` a remote app, pass it in the parameters::
 
-    oauth.register('twitter', {
-        'client_key': '...',
-        'client_secret': '...',
+    oauth.register('twitter',
+        client_key='...',
+        client_secret='...',
         ...,
-        'compliance_fix': compliance_fix,
+        compliance_fix=compliance_fix,
         ...
-    })
+    )


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Other, please describe:

According to [definition](https://github.com/lepture/authlib/blob/master/authlib/flask/client/oauth.py#L85), the docs for `OAuth.register` is incorrect. should be `oauth.register('twitter', **{...})` rather than `oauth.register('twitter', {...})`.

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
