### PR TITLE
Allow RefreshTokenGrant to validate client / token relationship

### DIFF
--- a/authlib/specs/rfc6749/grants/refresh_token.py
+++ b/authlib/specs/rfc6749/grants/refresh_token.py
@@ -105,10 +105,9 @@ class RefreshTokenGrant(BaseGrant):
 
             grant_type=refresh_token&refresh_token=tGzv3JOkF0XG5Qx2TlKWIA
         """
-        client = self._validate_request_client()
+        self.request.client = self._validate_request_client()
         token = self._validate_request_token()
         self._validate_token_scope(token)
-        self.request.client = client
         self.request.credential = token
 
     def create_token_response(self):


### PR DESCRIPTION
Servers may bind tokens to client IDs to reduce chance of token abuse [[1]](https://tools.ietf.org/html/rfc6819#section-5.1.5.8), but `RefreshTokenGrant` does not allow for this functionality.

In `validate_token_request`, the client is validated before the user function `authenticate_refresh_token` is called, but the client isn't saved as an instance variable until after that function call.  

This change allows `authenticate_refresh_token` to access the client with `self.request.client` to allow this functionality while not changing the API of `authenticate_refresh_token`

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

(If no, please delete the above question and this text message.)

---

- [X] You consent that the copyright of your pull request source code belongs to Authlib's author.
