### PR TITLE
Remove client secret check for refresh token

### DIFF
--- a/authlib/specs/rfc6749/grants/refresh_token.py
+++ b/authlib/specs/rfc6749/grants/refresh_token.py
@@ -36,9 +36,6 @@ class RefreshTokenGrant(BaseGrant):
         client = self.authenticate_token_endpoint_client()
         log.debug('Validate token request of {!r}'.format(client))
 
-        if not client.has_client_secret():
-            raise UnauthorizedClientError()
-
         if not client.check_grant_type(self.GRANT_TYPE):
             raise UnauthorizedClientError()
 


### PR DESCRIPTION
In case of creating client with authenticate_none method (in password flow), we shouldn't check client's 
secret, because he couldn't have one.

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
