### PR TITLE
Fix grant_user logic

### DIFF
--- a/authlib/flask/oauth2/authorization_server.py
+++ b/authlib/flask/oauth2/authorization_server.py
@@ -228,10 +228,6 @@ class AuthorizationServer(_AuthorizationServer):
                     grant_user = None
                 return server.create_authorization_response(grant_user=grant_user)
         """
-        if request and not grant_user:  # pragma: no cover
-            grant_user = request
-            request = None
-
         status, body, headers = self.create_valid_authorization_response(
             _create_oauth2_request(request),
             grant_user=grant_user


### PR DESCRIPTION
Unclear logic, is this fix for wrong arguments order? It will not work in case of not None request and None grant_user.
AttributeError: 'Request' object has no attribute 'generate_user_info'

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
