### PR TITLE
Return 401 on Authorization header errors

### DIFF
--- a/authlib/specs/rfc6749/errors.py
+++ b/authlib/specs/rfc6749/errors.py
@@ -180,6 +180,7 @@ class AccessDeniedError(OAuth2Error):
 
 class MissingAuthorizationError(OAuth2Error):
     error = 'missing_authorization'
+    status_code = 401
 
     def get_error_description(self):
         return self.gettext('Missing "Authorization" in headers.')
@@ -187,6 +188,7 @@ class MissingAuthorizationError(OAuth2Error):
 
 class UnsupportedTokenTypeError(OAuth2Error):
     error = 'unsupported_token_type'
+    status_code = 401
 
 
 # -- exceptions for clients -- #

--- a/tests/flask/test_oauth2/test_oauth2_server.py
+++ b/tests/flask/test_oauth2/test_oauth2_server.py
@@ -62,13 +62,13 @@ class ResourceTest(TestCase):
         self.prepare_data()
 
         rv = self.client.get('/user')
-        self.assertEqual(rv.status_code, 400)
+        self.assertEqual(rv.status_code, 401)
         resp = json.loads(rv.data)
         self.assertEqual(resp['error'], 'missing_authorization')
 
         headers = {'Authorization': 'invalid token'}
         rv = self.client.get('/user', headers=headers)
-        self.assertEqual(rv.status_code, 400)
+        self.assertEqual(rv.status_code, 401)
         resp = json.loads(rv.data)
         self.assertEqual(resp['error'], 'unsupported_token_type')
 


### PR DESCRIPTION
Make MissingAuthorizationError and UnsupportedTokenTypeError return
status code 401.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [X] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

Debatable, it is an API change, but clients will probably catch all 4xx errors.

---

- [X] You consent that the copyright of your pull request source code belongs to Authlib's author.
