### PR TITLE
Fix str + int addition and add option to customize default response_mode via environment variable.

### DIFF
--- a/authlib/oidc/core/grants/util.py
+++ b/authlib/oidc/core/grants/util.py
@@ -1,5 +1,6 @@
 import time
 import random
+import os
 from authlib.oauth2.rfc6749 import InvalidRequestError
 from authlib.oauth2.rfc6749.util import scope_to_list
 from authlib.jose import JWT
@@ -79,7 +80,7 @@ def generate_id_token(
 
 def create_response_mode_response(redirect_uri, params, response_mode=None):
     if response_mode is None:
-        response_mode = 'fragment'
+        response_mode = os.getenv('AUTHLIB_DEFAULT_RESPONSE_CODE', 'fragment')
 
     if response_mode == 'form_post':
         tpl = (

--- a/authlib/oidc/core/grants/util.py
+++ b/authlib/oidc/core/grants/util.py
@@ -132,7 +132,7 @@ def _generate_id_token_payload(
         'iss': iss,
         'aud': aud,
         'iat': now,
-        'exp': now + exp,
+        'exp': now + int(exp),
         'auth_time': auth_time,
     }
     if nonce:


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x ] Bugfix
- [ x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ x] No

---

- [ x] You consent that the copyright of your pull request source code belongs to Authlib's author.

Explanation:
I was experiencing issues with setting the 'exp' claim on the id_token payload where it was trying to add a string and an int. I made a simple change to cast the expiration to an integer. 

In addition, I had a OIDC client that required a response_mode of query. I added an option to set the response_mode via an environment variable. It still defaults to "fragment" if no environment variable is found. 
