### PR TITLE
Initialize OAuth2Auth with just client

### DIFF
--- a/authlib/oauth2/client_auth.py
+++ b/authlib/oauth2/client_auth.py
@@ -83,9 +83,15 @@ class TokenAuth(object):
     def register_sign_method(cls, sign_type, func):
         cls.SIGN_METHODS[sign_type] = func
 
-    def __init__(self, token, token_placement='header', client=None):
-        self.token = OAuth2Token.from_dict(token)
-        self.token_placement = token_placement
+    def __init__(self, token=None, token_placement=None, client=None):
+        if client and hasattr(client, 'token_auth'):
+            default_token = client.token_auth.token
+            default_token_placement = client.token_auth.token_placement
+        else:
+            default_token = None
+            default_token_placement = 'header'
+        self.token = OAuth2Token.from_dict(token or default_token)
+        self.token_placement = token_placement or default_token_placement
         self.client = client
         self.hooks = set()
 

--- a/tests/core/test_client/test_oauth2_session.py
+++ b/tests/core/test_client/test_oauth2_session.py
@@ -426,5 +426,5 @@ class OAuth2AuthTest(TestCase):
 
         sess = requests.Session()
         sess.send = verifier
-        auth = OAuth2Auth(token=client.token, client=client)
+        auth = OAuth2Auth(client=client)
         sess.get('https://i.b', auth=auth)


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.

A small change allowing to init `OAuth2Auth` with just single argument `client` (enabling auth-refresh feature).
