### PR TITLE
Fixed pseudo RNG being used in token generation

### DIFF
--- a/authlib/common/security.py
+++ b/authlib/common/security.py
@@ -1,12 +1,12 @@
 import os
 import string
-import random
+import secrets
 
 UNICODE_ASCII_CHARACTER_SET = string.ascii_letters + string.digits
 
 
 def generate_token(length=30, chars=UNICODE_ASCII_CHARACTER_SET):
-    rand = random.SystemRandom()
+    rand = secrets.SystemRandom()
     return ''.join(rand.choice(chars) for _ in range(length))
 
 


### PR DESCRIPTION
Changed the generate_token function to use a cryptographically strong random number generator from the secrets module, see https://docs.python.org/3.7/library/random.html for more info. Note, this fix requires Python 3.6+.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Other, please describe:
Fixes potential security vulnerability.

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:
The secrets module is new in Python 3.6, since this is a security fix the recommended migration path is to update Python and Authlib.

(If no, please delete the above question and this text message.)

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
