### PR TITLE
Support Custom Grant Type when fetching tokens with Username/Password

### DIFF
--- a/authlib/oauth2/client.py
+++ b/authlib/oauth2/client.py
@@ -157,8 +157,9 @@ class OAuth2Client(object):
         elif username and password:
             if 'scope' not in kwargs and self.scope:
                 kwargs['scope'] = self.scope
+            grant_type = kwargs.pop('grant_type', 'password')
             body = prepare_token_request(
-                'password', body, username=username,
+                grant_type, body, username=username,
                 password=password, **kwargs)
         else:
             grant_type = kwargs.pop('grant_type', 'client_credentials')


### PR DESCRIPTION
For example, this allows use with some custom grant type with
username/password like Auth0's "Realm Support":
https://auth0.com/docs/api-auth/tutorials/password-grant#realm-support

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Other, please describe:

Allow additional option for users.

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

(If no, please delete the above question and this text message.)

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
