### PR TITLE
[security] Fix bug where client can use any valid refresh credential

### DIFF
--- a/authlib/oauth2/rfc6749/grants/refresh_token.py
+++ b/authlib/oauth2/rfc6749/grants/refresh_token.py
@@ -126,7 +126,7 @@ class RefreshTokenGrant(BaseGrant):
             scope = credential.get_scope()
 
         client = self.request.client
-        if client.client_id != credential.client_id:
+        if client and client.client_id != credential.client_id:
             raise InvalidClientError('Invalid client for refresh token')
         
         expires_in = credential.get_expires_in()

--- a/authlib/oauth2/rfc6749/grants/refresh_token.py
+++ b/authlib/oauth2/rfc6749/grants/refresh_token.py
@@ -54,7 +54,9 @@ class RefreshTokenGrant(BaseGrant):
             )
 
         token = self.authenticate_refresh_token(refresh_token)
-        if not token:
+        client = self.request.client
+        
+        if (client and client.client_id != credential.client_id) or not token:
             raise InvalidGrantError()
         return token
 
@@ -124,10 +126,6 @@ class RefreshTokenGrant(BaseGrant):
         scope = self.request.scope
         if not scope:
             scope = credential.get_scope()
-
-        client = self.request.client
-        if client and client.client_id != credential.client_id:
-            raise InvalidClientError('Invalid client for refresh token')
         
         expires_in = credential.get_expires_in()
         token = self.generate_token(

--- a/authlib/oauth2/rfc6749/grants/refresh_token.py
+++ b/authlib/oauth2/rfc6749/grants/refresh_token.py
@@ -126,7 +126,6 @@ class RefreshTokenGrant(BaseGrant):
         scope = self.request.scope
         if not scope:
             scope = credential.get_scope()
-        
         expires_in = credential.get_expires_in()
         token = self.generate_token(
             client, self.GRANT_TYPE,

--- a/authlib/oauth2/rfc6749/grants/refresh_token.py
+++ b/authlib/oauth2/rfc6749/grants/refresh_token.py
@@ -15,6 +15,7 @@ from ..errors import (
     InvalidRequestError,
     InvalidScopeError,
     InvalidGrantError,
+    InvalidClientError,
     UnauthorizedClientError,
 )
 log = logging.getLogger(__name__)
@@ -125,6 +126,9 @@ class RefreshTokenGrant(BaseGrant):
             scope = credential.get_scope()
 
         client = self.request.client
+        if client.client_id != credential.client_id:
+            raise InvalidClientError('Invalid client for refresh token')
+        
         expires_in = credential.get_expires_in()
         token = self.generate_token(
             client, self.GRANT_TYPE,


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.

There is no check that the client & credential.client_id are the same, this adds the check and conforms to [RFC6749](https://tools.ietf.org/html/rfc6749#section-6)

```
The authorization server MUST:
authenticate the client if client authentication is included and
      ensure that the refresh token was issued to the authenticated
      client
```