### PR TITLE
Add Starlette client (#148)

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -26,3 +26,8 @@ checks:
 
   similar-code:
     enabled: false
+
+  identical-code:
+    enabled: true
+    config:
+      threshold: 100

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ matrix:
   - python: 2.7
     env: TOXENV=py27,flask,py27-django
   - python: 3.6
-    env: TOXENV=py36,flask,py36-django
+    env: TOXENV=py36,flask,py36-django,py36-starlette
   - python: 3.7
     dist: xenial
     sudo: true
-    env: TOXENV=py37,flask,py37-django
+    env: TOXENV=py37,flask,py37-django,py37-starlette
 
 install:
   - pip install -U setuptools

--- a/authlib/integrations/starlette_client/__init__.py
+++ b/authlib/integrations/starlette_client/__init__.py
@@ -1,0 +1,7 @@
+# flake8: noqa
+
+from .oauth_registry import OAuth
+from .remote_app import RemoteApp
+
+
+__all__ = ["OAuth", "RemoteApp"]

--- a/authlib/integrations/starlette_client/oauth_registry.py
+++ b/authlib/integrations/starlette_client/oauth_registry.py
@@ -1,0 +1,52 @@
+import functools
+from .remote_app import RemoteApp
+
+__all__ = ["OAuth"]
+
+
+class OAuth(object):
+    """Registry for oauth clients.
+
+    Create an instance for registry::
+
+        oauth = OAuth()
+    """
+
+    def __init__(self, fetch_token=None):
+        self._clients = {}
+        self.fetch_token = fetch_token
+
+    def register(self, name, **kwargs):
+        """Register a new remote application.
+
+        :param name: Name of the remote application.
+        :param kwargs: Parameters for :class:`RemoteApp`.
+
+        Find parameters from :class:`~authlib.client.OAuthClient`.
+        When a remote app is registered, it can be accessed with
+        *named* attribute::
+
+            oauth.register('twitter', client_id='', ...)
+            oauth.twitter.get('timeline')
+
+        """
+        client_cls = kwargs.pop("client_cls", RemoteApp)
+        fetch_token = kwargs.pop("fetch_token", None)
+        if not fetch_token and self.fetch_token:
+            fetch_token = functools.partial(self.fetch_token, name)
+
+        compliance_fix = kwargs.pop("compliance_fix", None)
+        client = client_cls(name, fetch_token=fetch_token, **kwargs)
+        if compliance_fix:
+            client.compliance_fix = compliance_fix
+
+        self._clients[name] = client
+        return client
+
+    def __getattr__(self, key):
+        try:
+            return object.__getattribute__(self, key)
+        except AttributeError:
+            if key in self._clients:
+                return self._clients[key]
+            raise AttributeError("No such client: %s" % key)

--- a/authlib/integrations/starlette_client/remote_app.py
+++ b/authlib/integrations/starlette_client/remote_app.py
@@ -19,12 +19,6 @@ class RemoteApp(OAuthClient):
 
     """
 
-    def __init__(self, name, fetch_token=None, **kwargs):
-        super(RemoteApp, self).__init__(**kwargs)
-
-        self.name = name
-        self._fetch_token = fetch_token
-
     def save_authorize_state(self, request, redirect_uri=None, state=None):
         """Save ``redirect_uri`` and ``state`` into session during authorization step.
 

--- a/authlib/starlette/client/__init__.py
+++ b/authlib/starlette/client/__init__.py
@@ -1,0 +1,3 @@
+# flake8: noqa
+
+from .oauth import OAuth, RemoteApp

--- a/authlib/starlette/client/__init__.py
+++ b/authlib/starlette/client/__init__.py
@@ -1,3 +1,0 @@
-# flake8: noqa
-
-from .oauth import OAuth, RemoteApp

--- a/authlib/starlette/client/oauth.py
+++ b/authlib/starlette/client/oauth.py
@@ -111,7 +111,7 @@ class RemoteApp(OAuthClient):
                 vf_key = _code_verifier_tpl.format(self.name)
                 request.session[vf_key] = code_verifier
 
-        uri, state = self.generate_authorize_redirect(
+        uri, state = self.create_authorization_url(
             redirect_uri, save_temporary_data, **kwargs
         )
         self.save_authorize_state(request, redirect_uri, state)

--- a/authlib/starlette/client/oauth.py
+++ b/authlib/starlette/client/oauth.py
@@ -117,6 +117,9 @@ class RemoteApp(OAuthClient):
         self.save_authorize_state(request, redirect_uri, state)
         return RedirectResponse(uri)
 
+    def _send_token_update(self, token):
+        pass
+
     def authorize_access_token(self, request, **kwargs):
         """Fetch an access token.
 

--- a/authlib/starlette/client/oauth.py
+++ b/authlib/starlette/client/oauth.py
@@ -1,0 +1,154 @@
+import functools
+from starlette.responses import RedirectResponse
+from authlib.client import OAuthClient
+from authlib.client.errors import MismatchingStateError
+
+
+__all__ = ["OAuth", "RemoteApp"]
+
+
+_req_token_tpl = "_{}_authlib_req_token_"
+_callback_tpl = "_{}_authlib_callback_"
+_state_tpl = "_{}_authlib_state_"
+_code_verifier_tpl = "_{}_authlib_code_verifier_"
+
+
+class OAuth(object):
+    """Registry for oauth clients.
+
+    Create an instance for registry::
+
+        oauth = OAuth()
+    """
+
+    def __init__(self, fetch_token=None):
+        self._clients = {}
+        self.fetch_token = fetch_token
+
+    def register(self, name, **kwargs):
+        """Register a new remote application.
+
+        :param name: Name of the remote application.
+        :param kwargs: Parameters for :class:`RemoteApp`.
+
+        Find parameters from :class:`~authlib.client.OAuthClient`.
+        When a remote app is registered, it can be accessed with
+        *named* attribute::
+
+            oauth.register('twitter', client_id='', ...)
+            oauth.twitter.get('timeline')
+
+        """
+        client_cls = kwargs.pop("client_cls", RemoteApp)
+        fetch_token = kwargs.pop("fetch_token", None)
+        if not fetch_token and self.fetch_token:
+            fetch_token = functools.partial(self.fetch_token, name)
+
+        compliance_fix = kwargs.pop("compliance_fix", None)
+        client = client_cls(name, fetch_token=fetch_token, **kwargs)
+        if compliance_fix:
+            client.compliance_fix = compliance_fix
+
+        self._clients[name] = client
+        return client
+
+    def __getattr__(self, key):
+        try:
+            return object.__getattribute__(self, key)
+        except AttributeError:
+            if key in self._clients:
+                return self._clients[key]
+            raise AttributeError("No such client: %s" % key)
+
+
+class RemoteApp(OAuthClient):
+    """Starlette integrated RemoteApp of :class:`~authlib.client.OAuthClient`.
+
+    This has built-in hooks for ``OAuthClient``.
+
+    """
+
+    def __init__(self, name, fetch_token=None, **kwargs):
+        super(RemoteApp, self).__init__(**kwargs)
+
+        self.name = name
+        self._fetch_token = fetch_token
+
+    def save_authorize_state(self, request, redirect_uri=None, state=None):
+        """Save ``redirect_uri`` and ``state`` into session during authorization step.
+
+        :param request: Starlette Request instance.
+        :param redirect_uri: Callback or redirect URI for authorization.
+        :param state: State string preventing CSRF.
+
+        """
+        if redirect_uri:
+            key = _callback_tpl.format(self.name)
+            request.session[key] = redirect_uri
+
+        if state:
+            state_key = _state_tpl.format(self.name)
+            request.session[state_key] = state
+
+    def authorize_redirect(self, request, redirect_uri=None, **kwargs):
+        """Create a HTTP Redirect for Authorization Endpoint.
+
+        :param request: Starlette Request instance.
+        :param redirect_uri: Callback or redirect URI for authorization.
+        :param kwargs: Extra parameters to include.
+        :return: Starlette ``RedirectResponse`` instance.
+
+        """
+        if self.request_token_url:
+
+            def save_temporary_data(token):
+                req_key = _req_token_tpl.format(self.name)
+                request.session[req_key] = token
+
+        else:
+
+            def save_temporary_data(code_verifier):
+                vf_key = _code_verifier_tpl.format(self.name)
+                request.session[vf_key] = code_verifier
+
+        uri, state = self.generate_authorize_redirect(
+            redirect_uri, save_temporary_data, **kwargs
+        )
+        self.save_authorize_state(request, redirect_uri, state)
+        return RedirectResponse(uri)
+
+    def authorize_access_token(self, request, **kwargs):
+        """Fetch an access token.
+
+        :param request: Starlette Request instance.
+        :return: A token dict.
+
+        """
+        if self.request_token_url:
+            req_key = _req_token_tpl.format(self.name)
+            request_token = request.session.pop(req_key, None)
+            params = request.scope
+        else:
+            request_token = None
+
+            params = {}
+            params["code"] = request.query_params["code"]
+
+            request_state = request.query_params["state"]
+            state_key = _state_tpl.format(self.name)
+            session_state = request.session.pop(state_key, None)
+
+            if session_state:
+                if session_state != request_state:
+                    raise MismatchingStateError()
+                params["state"] = session_state
+
+            vf_key = _code_verifier_tpl.format(self.name)
+            code_verifier = request.session.pop(vf_key, None)
+            if code_verifier:
+                params["code_verifier"] = code_verifier
+
+        cb_key = _callback_tpl.format(self.name)
+        redirect_uri = request.session.get(cb_key, None)
+
+        return self.fetch_access_token(redirect_uri, request_token, **{**params, **kwargs})

--- a/docs/client/starlette.rst
+++ b/docs/client/starlette.rst
@@ -7,7 +7,7 @@ Starlette OAuth Client
     :description: The built-in Starlette integrations for OAuth 1.0 and
         OAuth 2.0 clients.
 
-.. module:: authlib.starlette.client
+.. module:: authlib.integrations.starlette_client
     :noindex:
 
 The Starlette client provides integration with the Starlette ASGI framework and
@@ -23,7 +23,7 @@ functionality to be configured from the application settings or object.
 
 Create a registry with :class:`OAuth` object::
 
-    from authlib.starlette.client import OAuth
+    from authlib.integrations.starlette_client import OAuth
 
     oauth = OAuth()
 

--- a/docs/client/starlette.rst
+++ b/docs/client/starlette.rst
@@ -1,0 +1,377 @@
+.. _starlette_client:
+
+Starlette OAuth Client
+===================
+
+.. meta::
+    :description: The built-in Starlette integrations for OAuth 1.0 and
+        OAuth 2.0 clients.
+
+.. module:: authlib.starlette.client
+    :noindex:
+
+The Starlette client provides integration with the Starlette ASGI framework and
+can also be used with third party packages such as FastAPI and Bocadillo which
+are built on top of Starlette.
+
+The Starlette client shares a similar API with Flask client. But there are
+differences, since Starlette has no request context, you need to pass in
+instances of the Starlette ``Request`` object to the methods of the client.
+
+Unlike the Flask and Django clients, the Starlette client does not contain
+functionality to be configured from the application settings or object.
+
+Create a registry with :class:`OAuth` object::
+
+    from authlib.starlette.client import OAuth
+
+    oauth = OAuth()
+
+The common use case for OAuth is authentication, e.g. let your users log in
+with Twitter, GitHub, Google etc.
+
+Log In with OAuth 1.0
+---------------------
+
+For example, Twitter is an OAuth 1.0 service, you want your users to log in
+your website with Twitter.
+
+The first step is register a remote application on the ``OAuth`` registry via
+:meth:`~OAuth.register` method::
+
+    oauth.register(
+        name='twitter',
+        client_id='{{ your-twitter-consumer-key }}',
+        client_secret='{{ your-twitter-consumer-secret }}',
+        request_token_url='https://api.twitter.com/oauth/request_token',
+        request_token_params=None,
+        access_token_url='https://api.twitter.com/oauth/access_token',
+        access_token_params=None,
+        authorize_url='https://api.twitter.com/oauth/authenticate',
+        api_base_url='https://api.twitter.com/1.1/',
+        client_kwargs=None,
+    )
+
+The first parameter in ``register`` method is the **name** of the remote
+application. You can access the remote application with::
+
+    oauth.twitter.get('account/verify_credentials.json')
+
+The ``client_kwargs`` is a dict configuration to pass extra parameters to
+``OAuth1Session``. If you are using ``RSA-SHA1`` signature method::
+
+    client_kwargs = {
+        'signature_method': 'RSA-SHA1',
+        'signature_type': 'HEADER',
+        'rsa_key': 'Your-RSA-Key'
+    }
+
+Saving Temporary Credentials
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+With OAuth 1.0, we need to use a temporary credential to exchange for an access token.
+This temporary credential is created before redirecting to the provider (Twitter),
+and needs to be saved somewhere in order to use it later.
+
+With OAuth 1, the Starlette client will save the request token in sessions. To
+enable this, we need to add the ``SessionMiddleware`` middleware to the
+application, which requires the installation of the ``itsdangerous`` package::
+
+    from starlette.applications import Starlette
+    from starlette.middleware.sessions import SessionMiddleware
+    app = Starlette()
+    app.add_middleware(SessionMiddleware, secret_key="xxxxx")
+
+
+.. warning::
+
+    Using the ``SessionMiddleware`` will store the temporary credential as a
+    secure cookie which will expose your request token to the client.
+
+Routes for Authorization
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+After the configuration of the ``OAuth`` registry and the remote application, it
+is necessary to created the required routes and their associated functions. This
+requires two routes:
+
+1. A route to redirect to the 3rd party provider (Twitter) for authentication
+2. A route to redirect back to your website to fetch the access token and user
+   profile
+
+Here is the example for Twitter login::
+
+    from urllib.parse import urljoin, urlunsplit
+
+    def login(request: Request):
+        # build a full authorize callback uri
+        u = urlunsplit(request.url.components)
+        redirect_uri = urljoin(u, app.url_path_for("authorize"))
+        return oauth.twitter.authorize_redirect(request, redirect_uri)
+
+    def authorize(request: Request):
+        token = oauth.twitter.authorize_access_token(request)
+        resp = oauth.twitter.get('account/verify_credentials.json')
+        profile = resp.json()
+        # do something with the token and profile
+        return '...'
+
+After the user authenticates on the Twitter authorization page, they will be
+redirected back to your website ``authorize`` page. In this route function, you
+can get your user's twitter profile information, you can store the user
+information in your database, mark your user as logged in etc.
+
+
+Using OAuth 2.0 to Log In
+-------------------------
+
+For example, you want to use GitHub, which is an OAuth 2.0 service, to
+authenticate users for your API.
+
+The first step is register a remote application on the ``OAuth`` registry via
+:meth:`~OAuth.register` method::
+
+    oauth.register(
+        name='github',
+        client_id='{{ your-github-client-id }}',
+        client_secret='{{ your-github-client-secret }}',
+        access_token_url='https://github.com/login/oauth/access_token',
+        authorize_url='https://github.com/login/oauth/authorize',
+        api_base_url='https://api.github.com/',
+        client_kwargs={'scope': 'user:email'},
+    )
+
+The first parameter in ``register`` method is the **name** of the remote
+application. You can access the remote application with::
+
+    oauth.github.get('user')
+
+The ``client_kwargs`` is a configuration ``dict`` object to pass extra
+parameters to ``OAuth2Session``::
+
+    client_kwargs = {
+        'scope': 'profile',
+        'token_endpoint_auth_method': 'client_secret_basic',
+        'token_placement': 'header',
+    }
+
+There are several ``token_endpoint_auth_method`` methods detailed in
+:ref:`client_auth_methods`.
+
+
+Routes for Authorization
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+After the configuration of the ``OAuth`` registry and the remote application, it
+is necessary to created the required routes and their associated functions. This
+requires two routes:
+
+1. A route to redirect to the 3rd party provider (Twitter) for authentication
+2. A route to redirect back to your website to fetch the access token and user
+   profile
+
+Here is the example for GitHub login::
+
+    from urllib.parse import urljoin, urlunsplit
+
+    def login(request: Request):
+        # build a full authorize callback uri
+        u = urlunsplit(request.url.components)
+        redirect_uri = urljoin(u, app.url_path_for("authorize"))
+        return oauth.github.authorize_redirect(request, redirect_uri)
+
+    def authorize(request: Request):
+        token = oauth.github.authorize_access_token(request)
+        resp = oauth.github.get('user')
+        profile = resp.json()
+        # do something with the token and profile
+        return '...'
+
+After the user authenticates on the Twitter authorization page, they will be
+redirected back to your website ``authorize`` page. In this route function, you
+can get your user's twitter profile information, you can store the user
+information in your database, mark your user as logged in etc.
+
+Accessing OAuth Resources
+-------------------------
+
+It is possible to access your user's 3rd party OAuth provider resources, such as
+their user profile::
+
+    def github_profile(request):
+        token = OAuth2Token.objects.get(
+            name='github',
+            user=request.user
+        )
+        # API URL: https://api.github.com/user
+        resp = oauth.github.get('user', token=token.to_token())
+        profile = resp.json()
+        return render_template('github.html', profile=profile)
+
+In this case, we need a place to store the access token in order to use it
+later. For example, we may chose to store the access token server side in in a
+database.
+
+
+Database design for storing user access tokens
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Authlib Starlette client has no built-in database model, and so it is necessary to
+design a suitable Token model.
+
+Here are some hints on how to design your schema::
+
+    class OAuth1Token(models.Model):
+        name = models.CharField(max_length=40)
+        oauth_token = models.CharField(max_length=200)
+        oauth_token_secret = models.CharField(max_length=200)
+        # ...
+
+        def to_token(self):
+            return dict(
+                oauth_token=self.access_token,
+                oauth_token_secret=self.alt_token,
+            )
+
+    class OAuth2Token(models.Model):
+        name = models.CharField(max_length=40)
+        token_type = models.CharField(max_length=20)
+        access_token = models.CharField(max_length=200)
+        refresh_token = models.CharField(max_length=200)
+        # oauth 2 expires time
+        expires_at = models.DateTimeField()
+        # ...
+
+        def to_token(self):
+            return dict(
+                access_token=self.access_token,
+                token_type=self.token_type,
+                refresh_token=self.refresh_token,
+                expires_at=self.expires_at,
+            )
+
+And then we can save user's access token into the database when the user was redirected
+back to our ``authorize`` page::
+
+    def authorize(request):
+        token = oauth.github.authorize_access_token(request)
+        # OAuth2Token.save('github', token)
+        return RedirectResponse('/')
+
+Connect Token to Current User
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can always pass a ``token`` parameter to the remote application request
+methods like this::
+
+    oauth.twitter.get(url, token=token)
+    oauth.twitter.post(url, token=token)
+    oauth.twitter.put(url, token=token)
+    oauth.twitter.delete(url, token=token)
+
+And then you will need to fetch the token::
+
+    data = OAuth2Token.objects.get(
+            name='github',
+            user=request.user
+    )
+    token = data.to_token()
+
+However, it is more convenient to implement a ``fetch_token`` method to do this, since uou won't have
+to fetch the token every time, but instead pass the ``request`` instance::
+
+    def fetch_twitter_token(request):
+        item = OAuth1Token.objects.get(
+            name='twitter',
+            user=request.user
+        )
+        return item.to_token()
+
+    # we can register this ``fetch_token`` with oauth.register
+    oauth.register(
+        'twitter',
+        # ...
+        fetch_token=fetch_twitter_token,
+    )
+
+It's also possible to pass the ``fetch_token`` to ``OAuth`` registry so that
+it's not necessary to pass a ``fetch_token`` for each remote app registration.
+In this case, the ``fetch_token`` will accept two parameters::
+
+    def fetch_token(name, request):
+        if name in OAUTH1_SERVICES:
+            model = OAuth1Token
+        else:
+            model = OAuth2Token
+
+        item = model.objects.get(
+            name=name,
+            user=request.user
+        )
+        return item.to_token()
+
+    oauth = OAuth(fetch_token=fetch_token)
+
+Now, developers don't have to pass a ``token`` in the HTTP requests,
+instead, they can pass the ``request``::
+
+    def fetch_resource(request):
+        resp = oauth.twitter.get('account/verify_credentials.json', request=request)
+        profile = resp.json()
+        # ...
+
+Code Challenge
+--------------
+
+Adding ``code_challenge`` provided by :ref:`specs/rfc7636` is simple. You
+register your remote app with a ``code_challenge_method`` in ``client_kwargs``::
+
+    oauth.register(
+        'example',
+        client_id='Example Client ID',
+        client_secret='Example Client Secret',
+        access_token_url='https://example.com/oauth/access_token',
+        authorize_url='https://example.com/oauth/authorize',
+        api_base_url='https://api.example.com/',
+        client_kwargs={'code_challenge_method': 'S256'},
+    )
+
+Note, the only supportted ``code_challenge_method`` is ``S256``.
+
+Compliance Fix
+--------------
+
+The :class:`RemoteApp` is a subclass of :class:`~authlib.client.OAuthClient`,
+they share the same logic for compliance fix. Construct a method to fix
+the ``session`` attribute of a ``Request`` instance::
+
+    def slack_compliance_fix(session):
+        def _fix(resp):
+            token = resp.json()
+            # slack returns no token_type
+            token['token_type'] = 'Bearer'
+            resp._content = to_unicode(json.dumps(token)).encode('utf-8')
+            return resp
+        session.register_compliance_hook('access_token_response', _fix)
+
+When :meth:`OAuth.register` a remote app, pass it in the parameters::
+
+    oauth.register(
+        'slack',
+        client_id='...',
+        client_secret='...',
+        ...,
+        compliance_fix=slack_compliance_fix,
+        ...
+    )
+
+Find all the available compliance hooks at :ref:`compliance_fix_oauth2`.
+
+
+Loginpass
+---------
+
+loginpass_ does not currently support Starlette. A pull request adding support
+to loginpass_ would be welcome.
+
+.. _loginpass: https://github.com/authlib/loginpass

--- a/docs/client/starlette.rst
+++ b/docs/client/starlette.rst
@@ -216,12 +216,13 @@ database.
 Database design for storing user access tokens
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The Authlib Starlette client has no built-in database model, and so it is necessary to
-design a suitable Token model.
+The Authlib Starlette client has no built-in database model, and so it is
+necessary to design a suitable Token model.
 
-Here are some hints on how to design your schema::
+Here are some hints on how to design your schema using SQLAlchemy::
 
-    class OAuth1Token(models.Model):
+    class OAuth1Token(Base):
+        __tablename__ = "oauth1tokens"
         name = models.CharField(max_length=40)
         oauth_token = models.CharField(max_length=200)
         oauth_token_secret = models.CharField(max_length=200)
@@ -233,7 +234,8 @@ Here are some hints on how to design your schema::
                 oauth_token_secret=self.alt_token,
             )
 
-    class OAuth2Token(models.Model):
+    class OAuth2Token(Base):
+        __tablename__ = "oauth2tokens"
         name = models.CharField(max_length=40)
         token_type = models.CharField(max_length=20)
         access_token = models.CharField(max_length=200)

--- a/tests/starlette/test_oauth_client.py
+++ b/tests/starlette/test_oauth_client.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from starlette.applications import Starlette as App
 from starlette.requests import Request
 from starlette.middleware.sessions import SessionMiddleware
-from authlib.starlette.client import OAuth
+from authlib.integrations.starlette_client import OAuth
 from ..client_base import mock_send_value, get_bearer_token
 
 

--- a/tests/starlette/test_oauth_client.py
+++ b/tests/starlette/test_oauth_client.py
@@ -1,0 +1,293 @@
+import mock
+from unittest import TestCase
+from starlette.applications import Starlette as App
+from starlette.requests import Request
+from starlette.middleware.sessions import SessionMiddleware
+from authlib.starlette.client import OAuth
+from ..client_base import mock_send_value, get_bearer_token
+
+
+class StarletteOAuthTest(TestCase):
+    def test_register_remote_app(self):
+        oauth = OAuth()
+        self.assertRaises(AttributeError, lambda: oauth.dev)
+
+        oauth.register("dev", client_id="dev", client_secret="dev")
+        self.assertEqual(oauth.dev.name, "dev")
+        self.assertEqual(oauth.dev.client_id, "dev")
+
+    def test_register_oauth1_remote_app(self):
+        app = App()
+        app.add_middleware(SessionMiddleware, secret_key="xxxxx")
+        oauth = OAuth()
+        oauth.register(
+            "dev",
+            client_id="dev",
+            client_secret="dev",
+            request_token_url="https://i.b/reqeust-token",
+            api_base_url="https://i.b/api",
+            access_token_url="https://i.b/token",
+            authorize_url="https://i.b/authorize",
+        )
+        self.assertEqual(oauth.dev.name, "dev")
+        self.assertEqual(oauth.dev.client_id, "dev")
+
+    def test_oauth1_authorize(self):
+        app = App()
+        app.add_middleware(SessionMiddleware, secret_key="xxxxx")
+        oauth = OAuth()
+        client = oauth.register(
+            "dev",
+            client_id="dev",
+            client_secret="dev",
+            request_token_url="https://i.b/reqeust-token",
+            api_base_url="https://i.b/api",
+            access_token_url="https://i.b/token",
+            authorize_url="https://i.b/authorize",
+        )
+
+        # with app.test_request_context():
+        with mock.patch("requests.sessions.Session.send") as send:
+            req_scope = {"type": "http", "session": {}}
+            req = Request(req_scope)
+            send.return_value = mock_send_value("oauth_token=foo&oauth_verifier=baz")
+            resp = client.authorize_redirect(req, "https://b.com/bar")
+            self.assertEqual(resp.status_code, 307)
+            url = resp.headers.get("Location")
+            self.assertIn("oauth_token=foo", url)
+            self.assertIsNotNone(req.session.get("_dev_authlib_req_token_"))
+
+        with mock.patch("requests.sessions.Session.send") as send:
+            send.return_value = mock_send_value("oauth_token=a&oauth_token_secret=b")
+            token = client.authorize_access_token(req)
+            self.assertEqual(token["oauth_token"], "a")
+
+    def test_oauth2_authorize(self):
+        app = App()
+        app.add_middleware(SessionMiddleware, secret_key="xxxxx")
+        oauth = OAuth()
+        client = oauth.register(
+            "dev",
+            client_id="dev",
+            client_secret="dev",
+            api_base_url="https://i.b/api",
+            access_token_url="https://i.b/token",
+            authorize_url="https://i.b/authorize",
+        )
+
+        req_scope = {"type": "http", "session": {}}
+        req = Request(req_scope)
+
+        resp = client.authorize_redirect(req, redirect_uri="https://b.com/bar")
+        self.assertEqual(resp.status_code, 307)
+
+        url = resp.headers.get("Location")
+        self.assertIn("state=", url)
+
+        state = req.session["_dev_authlib_state_"]
+        self.assertIsNotNone(state)
+
+        with mock.patch("requests.sessions.Session.send") as send:
+            send.return_value = mock_send_value(get_bearer_token())
+            req_scope.update(
+                {
+                    "path": "/",
+                    "query_string": "code=a&state={}".format(state).encode(),
+                    "session": req.session,
+                }
+            )
+            req = Request(req_scope)
+            token = client.authorize_access_token(req)
+            self.assertEqual(token["access_token"], "a")
+
+    def test_oauth2_authorize_code_challenge(self):
+        app = App()
+        app.add_middleware(SessionMiddleware, secret_key="xxxxx")
+        oauth = OAuth()
+        client = oauth.register(
+            "dev",
+            client_id="dev",
+            api_base_url="https://i.b/api",
+            access_token_url="https://i.b/token",
+            authorize_url="https://i.b/authorize",
+            client_kwargs={"code_challenge_method": "S256"},
+        )
+
+        req_scope = {"type": "http", "session": {}}
+        req = Request(req_scope)
+
+        resp = client.authorize_redirect(req, redirect_uri="https://b.com/bar")
+        self.assertEqual(resp.status_code, 307)
+
+        url = resp.headers.get("Location")
+        self.assertIn("code_challenge=", url)
+        self.assertIn("code_challenge_method=S256", url)
+
+        state = req.session["_dev_authlib_state_"]
+        self.assertIsNotNone(state)
+
+        verifier = req.session["_dev_authlib_code_verifier_"]
+        self.assertIsNotNone(verifier)
+
+        def fake_send(sess, req, **kwargs):
+            self.assertIn("code_verifier={}".format(verifier), req.body)
+            return mock_send_value(get_bearer_token())
+
+        req_scope.update(
+            {
+                "path": "/",
+                "query_string": "code=a&state={}".format(state).encode(),
+                "session": req.session,
+            }
+        )
+        req = Request(req_scope)
+
+        with mock.patch("requests.sessions.Session.send", fake_send):
+            token = client.authorize_access_token(req)
+            self.assertEqual(token["access_token"], "a")
+
+    def test_with_fetch_token_in_register(self):
+        def fetch_token(request):
+            return {"access_token": "dev", "token_type": "bearer"}
+
+        oauth = OAuth()
+        client = oauth.register(
+            "dev",
+            client_id="dev",
+            client_secret="dev",
+            api_base_url="https://i.b/api",
+            access_token_url="https://i.b/token",
+            authorize_url="https://i.b/authorize",
+            fetch_token=fetch_token,
+        )
+
+        def fake_send(sess, req, **kwargs):
+            self.assertEqual(sess.token["access_token"], "dev")
+            return mock_send_value(get_bearer_token())
+
+        with mock.patch("requests.sessions.Session.send", fake_send):
+            req_scope = {"type": "http", "session": {}}
+            req = Request(req_scope)
+            client.get("/user", request=req)
+
+    def test_with_fetch_token_in_oauth(self):
+        def fetch_token(name, request):
+            return {"access_token": name, "token_type": "bearer"}
+
+        oauth = OAuth(fetch_token)
+        client = oauth.register(
+            "dev",
+            client_id="dev",
+            client_secret="dev",
+            api_base_url="https://i.b/api",
+            access_token_url="https://i.b/token",
+            authorize_url="https://i.b/authorize",
+        )
+
+        def fake_send(sess, req, **kwargs):
+            self.assertEqual(sess.token["access_token"], "dev")
+            return mock_send_value(get_bearer_token())
+
+        with mock.patch("requests.sessions.Session.send", fake_send):
+            req_scope = {"type": "http", "session": {}}
+            req = Request(req_scope)
+            client.get("/user", request=req)
+
+    def test_access_token_with_fetch_token(self):
+        app = App()
+        app.add_middleware(SessionMiddleware, secret_key="xxxxx")
+        oauth = OAuth()
+        token = get_bearer_token()
+        client = oauth.register(
+            "dev",
+            client_id="dev",
+            client_secret="dev",
+            api_base_url="https://i.b/api",
+            access_token_url="https://i.b/token",
+            authorize_url="https://i.b/authorize",
+            fetch_token=lambda name: token,
+        )
+
+        def fake_send(sess, req, **kwargs):
+            auth = req.headers["Authorization"]
+            self.assertEqual(auth, "Bearer {}".format(token["access_token"]))
+            resp = mock.MagicMock()
+            resp.text = "hi"
+            resp.status_code = 200
+            return resp
+
+        with mock.patch("requests.sessions.Session.send", fake_send):
+            req_scope = {"type": "http", "session": {}}
+            req = Request(req_scope)
+            resp = client.get("/api/user", request=req)
+            self.assertEqual(resp.text, "hi")
+
+            # trigger ctx.authlib_client_oauth_token
+            resp = client.get("/api/user", request=req)
+            self.assertEqual(resp.text, "hi")
+
+    def test_request_with_refresh_token(self):
+        app = App()
+        app.add_middleware(SessionMiddleware, secret_key="xxxxx")
+        oauth = OAuth()
+
+        expired_token = {
+            "token_type": "Bearer",
+            "access_token": "expired-a",
+            "refresh_token": "expired-b",
+            "expires_in": "3600",
+            "expires_at": 1566465749,
+        }
+        client = oauth.register(
+            "dev",
+            client_id="dev",
+            client_secret="dev",
+            api_base_url="https://i.b/api",
+            access_token_url="https://i.b/token",
+            refresh_token_url="https://i.b/token",
+            authorize_url="https://i.b/authorize",
+            fetch_token=lambda name: expired_token,
+        )
+
+        def fake_send(sess, req, **kwargs):
+            if req.url == "https://i.b/token":
+                auth = req.headers["Authorization"]
+                self.assertIn("Basic", auth)
+                resp = mock.MagicMock()
+                resp.json = get_bearer_token
+                resp.status_code = 200
+                return resp
+
+            resp = mock.MagicMock()
+            resp.text = "hi"
+            resp.status_code = 200
+            return resp
+
+        with mock.patch("requests.sessions.Session.send", fake_send):
+            resp = client.get("/api/user", token=expired_token)
+            self.assertEqual(resp.text, "hi")
+
+    def test_request_withhold_token(self):
+        app = App()
+        app.add_middleware(SessionMiddleware, secret_key="xxxxx")
+        oauth = OAuth()
+        client = oauth.register(
+            "dev",
+            client_id="dev",
+            client_secret="dev",
+            api_base_url="https://i.b/api",
+            access_token_url="https://i.b/token",
+            authorize_url="https://i.b/authorize",
+        )
+
+        def fake_send(sess, req, **kwargs):
+            auth = req.headers.get("Authorization")
+            self.assertIsNone(auth)
+            resp = mock.MagicMock()
+            resp.text = "hi"
+            resp.status_code = 200
+            return resp
+
+        with mock.patch("requests.sessions.Session.send", fake_send):
+            resp = client.get("/api/user", withhold_token=True)
+            self.assertEqual(resp.text, "hi")

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     py{27,36,37}
     {py27,py36,py37}-flask
     {py27,py36,py37}-django
+    {py36,py37}-starlette
     coverage
 
 [testenv]
@@ -13,6 +14,8 @@ deps =
     flask: Flask-SQLAlchemy
     py27-django: Django>=1.11,<2.0
     {py36,py37}-django: Django>=2.0,<2.1
+    {py36,py37}-starlette: starlette>=0.12.7
+    {py36,py37}-starlette: itsdangerous>=1.1.0
     {py27,py36,py37}-django: pytest-django
 
 setenv =
@@ -20,7 +23,7 @@ setenv =
     TESTPATH=tests/core
     flask: TESTPATH=tests/flask
     {py27,py36,py37}-django: TESTPATH=tests/django
-
+    {py36,py37}-starlette: TESTPATH=tests/starlette
 commands =
     coverage run --source=authlib -p -m pytest {env:TESTPATH}
 


### PR DESCRIPTION
This commit adds a new Starlette client along with documentation and
tests. The Starlette client is suitable for use with frameworks that
build on top of Starlette such as FastAPI and Bocadillo.

This implements #148.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
