### PR TITLE
OAuth2Token expires_at should be integer

### DIFF
--- a/docs/client/frameworks.rst
+++ b/docs/client/frameworks.rst
@@ -313,7 +313,7 @@ how to design the database::
         token_type = String(length=40)
         access_token = String(length=200)
         refresh_token = String(length=200)
-        expires_at = Timestamp()
+        expires_at = PositiveIntegerField()
         user = ForeignKey(User)
 
         def to_token(self):


### PR DESCRIPTION
OAuth2Token "expires_at" should be integer as it is epoch type (number of seconds since 1970)

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Other, please describe:
documentation update
**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

(If no, please delete the above question and this text message.)

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
