### PR TITLE
Httpx sync drop

### DIFF
--- a/authlib/integrations/httpx_client/assertion_client.py
+++ b/authlib/integrations/httpx_client/assertion_client.py
@@ -1,4 +1,4 @@
-from httpx import Client, AsyncClient
+from httpx import Client
 from authlib.oauth2.rfc7521 import AssertionClient as _AssertionClient
 from authlib.oauth2.rfc7523 import JWTBearerGrant
 from .utils import extract_client_kwargs
@@ -45,7 +45,7 @@ class AssertionClient(_AssertionClient, Client):
             method, url, headers=headers, data=data, auth=auth, **kwargs)
 
 
-class AsyncAssertionClient(_AssertionClient, AsyncClient):
+class AsyncAssertionClient(_AssertionClient, Client):
     token_auth_class = OAuth2Auth
     JWT_BEARER_GRANT_TYPE = JWTBearerGrant.GRANT_TYPE
     ASSERTION_METHODS = {
@@ -57,7 +57,7 @@ class AsyncAssertionClient(_AssertionClient, AsyncClient):
                  claims=None, token_placement='header', scope=None, **kwargs):
 
         client_kwargs = extract_client_kwargs(kwargs)
-        AsyncClient.__init__(self, **client_kwargs)
+        Client.__init__(self, **client_kwargs)
 
         _AssertionClient.__init__(
             self, session=None,

--- a/authlib/integrations/httpx_client/oauth1_client.py
+++ b/authlib/integrations/httpx_client/oauth1_client.py
@@ -1,7 +1,7 @@
 import typing
-from httpx import Client, AsyncClient
-from httpx import AsyncRequest, AsyncResponse
-from httpx.middleware.base import BaseMiddleware
+from httpx import Client
+from httpx import Request, Request
+from httpx.middleware import Middleware
 from authlib.oauth1 import (
     SIGNATURE_HMAC_SHA1,
     SIGNATURE_TYPE_HEADER,
@@ -13,12 +13,12 @@ from .utils import extract_client_kwargs, auth_call
 from .._client import OAuthError
 
 
-class OAuth1Auth(BaseMiddleware, ClientAuth):
+class OAuth1Auth(Middleware, ClientAuth):
     """Signs the httpx request using OAuth 1 (RFC5849)"""
 
     async def __call__(
-        self, request: AsyncRequest, get_response: typing.Callable
-    ) -> AsyncResponse:
+        self, request: Request, get_response: typing.Callable
+    ) -> Request:
         return await auth_call(self, request, get_response)
 
 
@@ -49,7 +49,7 @@ class OAuth1Client(_OAuth1Client, Client):
         raise OAuthError(error_type, error_description)
 
 
-class AsyncOAuth1Client(_OAuth1Client, AsyncClient):
+class AsyncOAuth1Client(_OAuth1Client, Client):
     auth_class = OAuth1Auth
 
     def __init__(self, client_id, client_secret=None,
@@ -60,7 +60,7 @@ class AsyncOAuth1Client(_OAuth1Client, AsyncClient):
                  force_include_body=False, **kwargs):
 
         _client_kwargs = extract_client_kwargs(kwargs)
-        AsyncClient.__init__(self, **_client_kwargs)
+        Client.__init__(self, **_client_kwargs)
 
         _OAuth1Client.__init__(
             self, None,

--- a/authlib/integrations/httpx_client/oauth2_client.py
+++ b/authlib/integrations/httpx_client/oauth2_client.py
@@ -1,6 +1,6 @@
 import typing
-from httpx import Client, AsyncClient
-from httpx.middleware.base import BaseMiddleware
+from httpx import Client
+from httpx.middleware import Middleware
 from httpx.models import (
     AsyncRequest,
     AsyncResponse,
@@ -22,7 +22,7 @@ __all__ = [
 ]
 
 
-class OAuth2Auth(BaseMiddleware, TokenAuth):
+class OAuth2Auth(Middleware, TokenAuth):
     """Sign requests for OAuth 2.0, currently only bearer token is supported."""
 
     async def __call__(
@@ -35,7 +35,7 @@ class OAuth2Auth(BaseMiddleware, TokenAuth):
             raise UnsupportedTokenTypeError(description=description)
 
 
-class OAuth2ClientAuth(BaseMiddleware, ClientAuth):
+class OAuth2ClientAuth(Middleware, ClientAuth):
     async def __call__(
         self, request: AsyncRequest, get_response: typing.Callable
     ) -> AsyncResponse:
@@ -122,7 +122,7 @@ class OAuth2Client(_OAuth2Client, Client):
             raise InvalidTokenError()
 
 
-class AsyncOAuth2Client(_OAuth2Client, AsyncClient):
+class AsyncOAuth2Client(_OAuth2Client, Client):
     SESSION_REQUEST_PARAMS = HTTPX_CLIENT_KWARGS
 
     client_auth_class = OAuth2ClientAuth
@@ -137,7 +137,7 @@ class AsyncOAuth2Client(_OAuth2Client, AsyncClient):
 
         # extract httpx.Client kwargs
         client_kwargs = self._extract_session_request_params(kwargs)
-        AsyncClient.__init__(self, **client_kwargs)
+        Client.__init__(self, **client_kwargs)
 
         _OAuth2Client.__init__(
             self, session=None,

--- a/authlib/integrations/httpx_client/oauth2_client.py
+++ b/authlib/integrations/httpx_client/oauth2_client.py
@@ -2,8 +2,8 @@ import typing
 from httpx import Client
 from httpx.middleware import Middleware
 from httpx.models import (
-    AsyncRequest,
-    AsyncResponse,
+    Request,
+    Response,
 )
 from authlib.common.urls import url_decode
 from authlib.oauth2.client import OAuth2Client as _OAuth2Client
@@ -26,8 +26,8 @@ class OAuth2Auth(Middleware, TokenAuth):
     """Sign requests for OAuth 2.0, currently only bearer token is supported."""
 
     async def __call__(
-        self, request: AsyncRequest, get_response: typing.Callable
-    ) -> AsyncResponse:
+        self, request: Request, get_response: typing.Callable
+    ) -> Response:
         try:
             return await auth_call(self, request, get_response, False)
         except KeyError as error:
@@ -37,8 +37,8 @@ class OAuth2Auth(Middleware, TokenAuth):
 
 class OAuth2ClientAuth(Middleware, ClientAuth):
     async def __call__(
-        self, request: AsyncRequest, get_response: typing.Callable
-    ) -> AsyncResponse:
+        self, request: Request, get_response: typing.Callable
+    ) -> Response:
         return await auth_call(self, request, get_response)
 
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

In the `0.8.0` release of httpx the sync support was dropped and some classes have been removed:
`AsyncClient, AsyncRequest, AsyncResponse` and moved to `Client, Request, Response`. Here some more information: [Commit](https://github.com/encode/httpx/commit/00e150f6a5f8d295faeadc34cfe53de254b3f264) / [Discussion](https://github.com/encode/httpx/issues/522)

This PR closes #171 and fixes:
- `AsyncClient`  is renamed to `Client` 
- `AsyncRequest` is renamed to `Request`
- `AsyncResponse` is renamed to `Response`
- `BaseMiddleware` is renamed to `Middleware`  

---
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
