### PR TITLE
Do not mutate default_json_header constant

### DIFF
--- a/authlib/common/errors.py
+++ b/authlib/common/errors.py
@@ -66,7 +66,7 @@ class AuthlibHTTPError(AuthlibBaseError):
         return error
 
     def get_headers(self):
-        return default_json_headers
+        return default_json_headers[:]
 
     def __call__(self, translations=None, error_uris=None):
         self._translations = translations


### PR DESCRIPTION
This fixes the issue when api request is made using wrong token multiple times.
WWW-Authenticate header is added on each response.

> DO NOT SEND ANY SECURITY FIX HERE. Please read "Security Reporting" section
> on README.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

(If no, please delete the above question and this text message.)

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
