### PR TITLE
Starlette: Force GET on authorize_redirect

### DIFF
--- a/authlib/integrations/starlette_client/remote_app.py
+++ b/authlib/integrations/starlette_client/remote_app.py
@@ -1,4 +1,5 @@
 from starlette.responses import RedirectResponse
+from starlette.status import HTTP_303_SEE_OTHER
 from ..asgi_client import AsyncBaseApp
 
 
@@ -26,7 +27,7 @@ class RemoteApp(AsyncBaseApp):
         """
         rv = await self.create_authorization_url(redirect_uri, **kwargs)
         self.save_authorize_data(request, redirect_uri=redirect_uri, **rv)
-        return RedirectResponse(rv['url'])
+        return RedirectResponse(rv['url'], status_code=HTTP_303_SEE_OTHER)
 
     async def authorize_access_token(self, request, **kwargs):
         """Fetch an access token.


### PR DESCRIPTION
Starlette uses 307 status code for RedirectResponse by default:
https://www.starlette.io/responses/#redirectresponse

This will reuse the same method of the original request:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307

...while RFC6749 only ensures that GET is accepted (POST is optional):
https://tools.ietf.org/html/rfc6749#section-3.1

By using HTTP_303_SEE_OTHER the redirect will always occur using a GET:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303

> DO NOT SEND ANY SECURITY FIX HERE. Please read "Security Reporting" section
> on README.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
