### PR TITLE
Removing the extra args while refreshing token

### DIFF
--- a/authlib/integrations/httpx_client/oauth2_client.py
+++ b/authlib/integrations/httpx_client/oauth2_client.py
@@ -81,7 +81,7 @@ class AsyncOAuth2Client(_OAuth2Client, AsyncClient):
                 raise MissingTokenError()
 
             if self.token.is_expired():
-                await self.ensure_active_token(**kwargs)
+                await self.ensure_active_token()
 
             auth = self.token_auth
 


### PR DESCRIPTION
Removes url parameters and/or form parameters while checking for refreshing token.  Closes Bug #201

> DO NOT SEND ANY SECURITY FIX HERE. Please read "Security Reporting" section
> on README.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

(If no, please delete the above question and this text message.)

---

- [ ] You consent that the copyright of your pull request source code belongs to Authlib's author.
