### PR TITLE
Requests Requests.post method does not have a auth argument. Call Req…

### DIFF
--- a/authlib/oauth1/client.py
+++ b/authlib/oauth1/client.py
@@ -154,7 +154,7 @@ class OAuth1Client(object):
         return token
 
     def _fetch_token(self, url, **kwargs):
-        resp = self.session.post(url, auth=self.auth, **kwargs)
+        resp = self.session.request('POST', url, auth=self.auth, **kwargs)
         token = self.parse_response_token(resp.status_code, resp.text)
         self.token = token
         self.auth.verifier = None


### PR DESCRIPTION
Requests Requests.post method does not have a auth argument. Call Requests.request method instead.

Fixes: #211

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

Will make OAuth1 client actually work.

---

- [X] You consent that the copyright of your pull request source code belongs to Authlib's author.
