### PR TITLE
Fix #213: Fixing auto-refresh token for client-credentials.

### DIFF
--- a/authlib/integrations/requests_client/oauth2_session.py
+++ b/authlib/integrations/requests_client/oauth2_session.py
@@ -24,6 +24,8 @@ class OAuth2Auth(AuthBase, TokenAuth):
                 client.refresh_token(url, refresh_token=refresh_token, **kwargs)
             elif client.metadata.get('grant_type') == 'client_credentials':
                 access_token = self.token['access_token']
+                kwargs.setdefault('client_id', self.client.client_id)
+                kwargs.setdefault('client_secret', self.client.client_secret)
                 token = client.fetch_token(
                     url, grant_type='client_credentials', **kwargs)
                 if client.update_token:


### PR DESCRIPTION
This change ensures that the client_id and client_secret kwargs are passed along
to the request for fetching a new access token when the previous one has expired.

> DO NOT SEND ANY SECURITY FIX HERE. Please read "Security Reporting" section
> on README.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
