### PR TITLE
Fixing Typo

### DIFF
--- a/docs/flask/1/authorization-server.rst
+++ b/docs/flask/1/authorization-server.rst
@@ -204,7 +204,7 @@ to fetch a temporary credential::
 
     @app.route('/initiate', methods=['POST'])
     def initiate_temporary_credential():
-        return server.create_temporary_credential_response()
+        return server.create_temporary_credentials_response()
 
 The endpoint for resource owner authorization. OAuth 1 Client will redirect
 user to this authorization page, so that resource owner can grant or deny this


### PR DESCRIPTION
The name of the `create_temporary_credential_response()` is wrong, there is missing and `s` in the `credential-s-` section.

> DO NOT SEND ANY SECURITY FIX HERE. Please read "Security Reporting" section
> on README.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x ] Other, please describe: Typo

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x ] No

If yes, please describe the impact and migration path for existing applications:

(If no, please delete the above question and this text message.)

---

- [x ] You consent that the copyright of your pull request source code belongs to Authlib's author.
