### PR TITLE
Fixing the name of the Nonce model

### DIFF
--- a/docs/flask/1/authorization-server.rst
+++ b/docs/flask/1/authorization-server.rst
@@ -106,9 +106,9 @@ built-in validation with cache.
 
 If cache is not available, there is also a SQLAlchemy mixin::
 
-    from authlib.integrations.sqla_oauth1 import OAuth1TokenCredentialMixin
+    from authlib.integrations.sqla_oauth1 import OAuth1TimestampNonceMixin
 
-    class TimestampNonce(db.Model, OAuth1TokenCredentialMixin)
+    class TimestampNonce(db.Model, OAuth1TimestampNonceMixin)
         id = db.Column(db.Integer, primary_key=True)
 
 


### PR DESCRIPTION
In the example to define the TimestampNonce there is referring to the `OAuth1TokenCredentialMixin` and should be `OAuth1TimestampNonceMixin`

> DO NOT SEND ANY SECURITY FIX HERE. Please read "Security Reporting" section
> on README.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

(If no, please delete the above question and this text message.)

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
