### PR TITLE
🐛 fix for "expires_at" / "expires_in" param when "None" is specified

### DIFF
--- a/authlib/oauth2/rfc6749/wrappers.py
+++ b/authlib/oauth2/rfc6749/wrappers.py
@@ -5,9 +5,9 @@ from .errors import InsecureTransportError
 
 class OAuth2Token(dict):
     def __init__(self, params):
-        if 'expires_at' in params:
+        if params.get('expires_at'):
             params['expires_at'] = int(params['expires_at'])
-        elif 'expires_in' in params:
+        elif params.get('expires_in'):
             params['expires_at'] = int(time.time()) + \
                                    int(params['expires_in'])
         super(OAuth2Token, self).__init__(params)


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**Description**
Some providers provide endless access tokens, therefore, if you specify None for expires_at or expires_in - a token initialization error occurs.

For example, such services are GitHub and Gitlab. Moreover, in the case of the Gitlab, the token for updating is returned, but without expires_at (long-live bug and it won't be fixed, probably).

**Links**:
* Gitlab token: https://stackoverflow.com/questions/39264452/gitlab-oauth-access-token-validity
* GitHub token: https://stackoverflow.com/questions/26902600/whats-the-lifetime-of-github-oauth-api-access-token

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
