### PR TITLE
Reflect changes in httpx upstream

### DIFF
--- a/authlib/integrations/httpx_client/oauth1_client.py
+++ b/authlib/integrations/httpx_client/oauth1_client.py
@@ -1,11 +1,9 @@
 import typing
-from httpx import AsyncClient, Auth
-from httpx import Request, Response
+from httpx import AsyncClient, Auth, Request, Response
 from authlib.oauth1 import (
     SIGNATURE_HMAC_SHA1,
     SIGNATURE_TYPE_HEADER,
 )
-from authlib.common.encoding import to_unicode
 from authlib.oauth1 import ClientAuth
 from authlib.oauth1.client import OAuth1Client as _OAuth1Client
 from .utils import extract_client_kwargs, rebuild_request
@@ -65,8 +63,9 @@ class AsyncOAuth1Client(_OAuth1Client, AsyncClient):
 
     async def _fetch_token(self, url, **kwargs):
         resp = await self.post(url, **kwargs)
-        text = await resp.aread()
-        token = self.parse_response_token(resp.status_code, to_unicode(text))
+        await resp.aread()
+        text = resp.text
+        token = self.parse_response_token(resp.status_code, text)
         self.token = token
         return token
 

--- a/authlib/integrations/httpx_client/utils.py
+++ b/authlib/integrations/httpx_client/utils.py
@@ -1,5 +1,6 @@
-from httpx import URL
-from httpx.content_streams import ByteStream
+import typing
+
+from httpx import URL, Request
 from authlib.common.encoding import to_bytes
 
 
@@ -19,12 +20,14 @@ def extract_client_kwargs(kwargs):
     return client_kwargs
 
 
-def rebuild_request(request, url, headers, body):
-    request.url = URL(url)
-    request.headers.update(headers)
-    if body:
-        body = to_bytes(body)
-        if body != request.content:
-            request._content = body
-            request.stream = ByteStream(body)
-    return request
+def rebuild_request(request: Request, url: typing.Union[str, URL],
+                    headers: typing.Mapping[typing.AnyStr, typing.AnyStr], body: typing.AnyStr):
+    new_request = Request(
+        method=request.method,
+        url=URL(url),
+        headers=request.headers,
+        data=to_bytes(body) if body is not None else None,
+        stream=request.stream if body is None else None,
+    )
+    new_request.headers.update(headers)
+    return new_request

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ with open('README.rst') as f:
 
 
 client_requires = ['requests']
+httpx_requires = ['httpx >= 0.12.0']
 crypto_requires = ['cryptography']
 
 
@@ -33,6 +34,7 @@ setup(
     install_requires=crypto_requires,
     extras_require={
         'client': client_requires,
+        'httpx': httpx_requires,
     },
     project_urls={
         'Documentation': 'https://docs.authlib.org/',

--- a/tests/django/base.py
+++ b/tests/django/base.py
@@ -18,5 +18,12 @@ class RequestClient(RequestFactory):
 
 
 class TestCase(_TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestCase, cls).setUpClass()
+        from . import settings as settings_module
+        if not settings.configured:
+            settings.configure(settings_module.__dict__)
+
     def setUp(self):
         self.factory = RequestClient()

--- a/tests/py3/test_httpx_client/test_async_assertion_client.py
+++ b/tests/py3/test_httpx_client/test_async_assertion_client.py
@@ -1,7 +1,7 @@
 import time
 import pytest
 from authlib.integrations.httpx_client import AsyncAssertionClient
-from tests.py3.utils import MockDispatch
+from tests.py3.utils import mock_dispatch
 
 
 default_token = {
@@ -15,9 +15,9 @@ default_token = {
 
 @pytest.mark.asyncio
 async def test_refresh_token():
-    def verifier(request):
+    async def verifier(request):
         if str(request.url) == 'https://i.b/token':
-            assert b'assertion=' in request.read()
+            assert b'assertion=' in await request.aread()
 
     async with AsyncAssertionClient(
         'https://i.b/token',
@@ -27,7 +27,7 @@ async def test_refresh_token():
         audience='foo',
         alg='HS256',
         key='secret',
-        dispatch=MockDispatch(default_token, assert_func=verifier)
+        dispatch=mock_dispatch(default_token, assert_func=verifier)
     ) as client:
         await client.get('https://i.b')
 
@@ -44,7 +44,7 @@ async def test_refresh_token():
         key='secret',
         scope='email',
         claims={'test_mode': 'true'},
-        dispatch=MockDispatch(default_token, assert_func=verifier)
+        dispatch=mock_dispatch(default_token, assert_func=verifier)
     ) as client:
         await client.get('https://i.b')
         await client.get('https://i.b')

--- a/tests/py3/test_httpx_client/test_async_oauth1_client.py
+++ b/tests/py3/test_httpx_client/test_async_oauth1_client.py
@@ -5,7 +5,7 @@ from authlib.integrations.httpx_client import (
     SIGNATURE_TYPE_BODY,
     SIGNATURE_TYPE_QUERY,
 )
-from tests.py3.utils import MockDispatch
+from tests.py3.utils import mock_dispatch
 
 oauth_url = 'https://example.com/oauth'
 
@@ -14,12 +14,12 @@ oauth_url = 'https://example.com/oauth'
 async def test_fetch_request_token_via_header():
     request_token = {'oauth_token': '1', 'oauth_token_secret': '2'}
 
-    def assert_func(request):
+    async def assert_func(request):
         auth_header = request.headers.get('authorization')
         assert 'oauth_consumer_key="id"' in auth_header
         assert 'oauth_signature=' in auth_header
 
-    dispatch = MockDispatch(request_token, assert_func=assert_func)
+    dispatch = mock_dispatch(request_token, assert_func=assert_func)
     async with AsyncOAuth1Client('id', 'secret', dispatch=dispatch) as client:
         response = await client.fetch_request_token(oauth_url)
 
@@ -30,14 +30,14 @@ async def test_fetch_request_token_via_header():
 async def test_fetch_request_token_via_body():
     request_token = {'oauth_token': '1', 'oauth_token_secret': '2'}
 
-    def assert_func(request):
+    async def assert_func(request):
         auth_header = request.headers.get('authorization')
         assert auth_header is None
 
-        assert b'oauth_consumer_key=id' in request.content
+        assert b'oauth_consumer_key=id' in await request.aread()
         assert b'&oauth_signature=' in request.content
 
-    mock_response = MockDispatch(request_token, assert_func=assert_func)
+    mock_response = mock_dispatch(request_token, assert_func=assert_func)
 
     async with AsyncOAuth1Client(
         'id', 'secret', signature_type=SIGNATURE_TYPE_BODY,
@@ -52,7 +52,7 @@ async def test_fetch_request_token_via_body():
 async def test_fetch_request_token_via_query():
     request_token = {'oauth_token': '1', 'oauth_token_secret': '2'}
 
-    def assert_func(request):
+    async def assert_func(request):
         auth_header = request.headers.get('authorization')
         assert auth_header is None
 
@@ -60,7 +60,7 @@ async def test_fetch_request_token_via_query():
         assert 'oauth_consumer_key=id' in url
         assert '&oauth_signature=' in url
 
-    mock_response = MockDispatch(request_token, assert_func=assert_func)
+    mock_response = mock_dispatch(request_token, assert_func=assert_func)
 
     async with AsyncOAuth1Client(
         'id', 'secret', signature_type=SIGNATURE_TYPE_QUERY,
@@ -75,14 +75,14 @@ async def test_fetch_request_token_via_query():
 async def test_fetch_access_token():
     request_token = {'oauth_token': '1', 'oauth_token_secret': '2'}
 
-    def assert_func(request):
+    async def assert_func(request):
         auth_header = request.headers.get('authorization')
         assert 'oauth_verifier="d"' in auth_header
         assert 'oauth_token="foo"' in auth_header
         assert 'oauth_consumer_key="id"' in auth_header
         assert 'oauth_signature=' in auth_header
 
-    mock_response = MockDispatch(request_token, assert_func=assert_func)
+    mock_response = mock_dispatch(request_token, assert_func=assert_func)
     async with AsyncOAuth1Client(
         'id', 'secret', token='foo', token_secret='bar',
         dispatch=mock_response,
@@ -97,7 +97,7 @@ async def test_fetch_access_token():
 
 @pytest.mark.asyncio
 async def test_get_via_header():
-    mock_response = MockDispatch(b'hello')
+    mock_response = mock_dispatch(b'hello')
     async with AsyncOAuth1Client(
         'id', 'secret', token='foo', token_secret='bar',
         dispatch=mock_response,
@@ -114,7 +114,7 @@ async def test_get_via_header():
 
 @pytest.mark.asyncio
 async def test_get_via_body():
-    mock_response = MockDispatch(b'hello')
+    mock_response = mock_dispatch(b'hello')
     async with AsyncOAuth1Client(
         'id', 'secret', token='foo', token_secret='bar',
         signature_type=SIGNATURE_TYPE_BODY,
@@ -128,14 +128,14 @@ async def test_get_via_body():
     auth_header = request.headers.get('authorization')
     assert auth_header is None
 
-    assert b'oauth_token=foo' in request.content
+    assert b'oauth_token=foo' in await request.aread()
     assert b'oauth_consumer_key=id' in request.content
     assert b'oauth_signature=' in request.content
 
 
 @pytest.mark.asyncio
 async def test_get_via_query():
-    mock_response = MockDispatch(b'hello')
+    mock_response = mock_dispatch(b'hello')
     async with AsyncOAuth1Client(
         'id', 'secret', token='foo', token_secret='bar',
         signature_type=SIGNATURE_TYPE_QUERY,

--- a/tests/py3/test_starlette_client/test_oauth_client.py
+++ b/tests/py3/test_starlette_client/test_oauth_client.py
@@ -2,7 +2,7 @@ import pytest
 from starlette.config import Config
 from starlette.requests import Request
 from authlib.integrations.starlette_client import OAuth
-from tests.py3.utils import PathMapDispatch
+from tests.py3.utils import path_map_dispatch
 from tests.client_base import get_bearer_token
 
 
@@ -39,7 +39,7 @@ def test_register_with_overwrite():
 @pytest.mark.asyncio
 async def test_oauth1_authorize():
     oauth = OAuth()
-    dispatch = PathMapDispatch({
+    dispatch = path_map_dispatch({
         '/request-token': {'body': 'oauth_token=foo&oauth_verifier=baz'},
         '/token': {'body': 'oauth_token=a&oauth_token_secret=b'},
     })
@@ -74,7 +74,7 @@ async def test_oauth1_authorize():
 @pytest.mark.asyncio
 async def test_oauth2_authorize():
     oauth = OAuth()
-    dispatch = PathMapDispatch({
+    dispatch = path_map_dispatch({
         '/token': {'body': get_bearer_token()}
     })
     client = oauth.register(
@@ -113,7 +113,7 @@ async def test_oauth2_authorize():
 
 @pytest.mark.asyncio
 async def test_oauth2_authorize_code_challenge():
-    dispatch = PathMapDispatch({
+    dispatch = path_map_dispatch({
         '/token': {'body': get_bearer_token()}
     })
     oauth = OAuth()
@@ -163,7 +163,7 @@ async def test_with_fetch_token_in_register():
     async def fetch_token(request):
         return {'access_token': 'dev', 'token_type': 'bearer'}
 
-    dispatch = PathMapDispatch({
+    dispatch = path_map_dispatch({
         '/user': {'body': {'sub': '123'}}
     })
     oauth = OAuth()
@@ -191,7 +191,7 @@ async def test_with_fetch_token_in_oauth():
     async def fetch_token(name, request):
         return {'access_token': 'dev', 'token_type': 'bearer'}
 
-    dispatch = PathMapDispatch({
+    dispatch = path_map_dispatch({
         '/user': {'body': {'sub': '123'}}
     })
     oauth = OAuth(fetch_token=fetch_token)
@@ -216,7 +216,7 @@ async def test_with_fetch_token_in_oauth():
 @pytest.mark.asyncio
 async def test_request_withhold_token():
     oauth = OAuth()
-    dispatch = PathMapDispatch({
+    dispatch = path_map_dispatch({
         '/user': {'body': {'sub': '123'}}
     })
     client = oauth.register(
@@ -252,7 +252,7 @@ async def test_oauth2_authorize_with_metadata():
         await client.create_authorization_url(req)
 
 
-    dispatch = PathMapDispatch({
+    dispatch = path_map_dispatch({
         '/.well-known/openid-configuration': {'body': {
             'authorization_endpoint': 'https://i.b/authorize'
         }}

--- a/tests/py3/test_starlette_client/test_user_mixin.py
+++ b/tests/py3/test_starlette_client/test_user_mixin.py
@@ -5,7 +5,7 @@ from authlib.jose import jwk
 from authlib.jose.errors import InvalidClaimError
 from authlib.oidc.core.grants.util import generate_id_token
 from tests.util import read_file_path
-from tests.py3.utils import PathMapDispatch
+from tests.py3.utils import path_map_dispatch
 from tests.client_base import get_bearer_token
 
 
@@ -15,7 +15,7 @@ async def run_fetch_userinfo(payload, compliance_fix=None):
     async def fetch_token(request):
         return get_bearer_token()
 
-    dispatch = PathMapDispatch({
+    dispatch = path_map_dispatch({
         '/userinfo': {'body': payload}
     })
 
@@ -125,7 +125,7 @@ async def test_force_fetch_jwks_uri():
         aud='dev', exp=3600, nonce='n',
     )
 
-    dispatch = PathMapDispatch({
+    dispatch = path_map_dispatch({
         '/jwks': {'body': read_file_path('jwks_public.json')}
     })
 


### PR DESCRIPTION
## Summary

This PR fixes and enhances the following:

* (fix) Replace the portions that depend on the httpx's private functions and classes so that authlib works httpx>=0.12.0  (See https://github.com/encode/httpx/pull/785)
* (feature) Make compliance hooks work with coroutine functions.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

## Contributor License Agreement

- [x] I consent that the copyright of your pull request source code belongs to Authlib's author.
