### PR TITLE
Import from the `httpx` public API.

### DIFF
--- a/authlib/integrations/httpx_client/oauth1_client.py
+++ b/authlib/integrations/httpx_client/oauth1_client.py
@@ -1,6 +1,5 @@
 import typing
-from httpx import AsyncClient, Auth
-from httpx import Request, Response
+from httpx import AsyncClient, Auth, Request, Response
 from authlib.oauth1 import (
     SIGNATURE_HMAC_SHA1,
     SIGNATURE_TYPE_HEADER,

--- a/authlib/integrations/httpx_client/oauth2_client.py
+++ b/authlib/integrations/httpx_client/oauth2_client.py
@@ -1,9 +1,5 @@
 import typing
-from httpx import AsyncClient, Auth
-from httpx.models import (
-    Request,
-    Response,
-)
+from httpx import AsyncClient, Auth, Request, Response
 from authlib.common.urls import url_decode
 from authlib.oauth2.client import OAuth2Client as _OAuth2Client
 from authlib.oauth2.auth import ClientAuth, TokenAuth

--- a/tests/py3/test_httpx_client/test_async_assertion_client.py
+++ b/tests/py3/test_httpx_client/test_async_assertion_client.py
@@ -15,9 +15,10 @@ default_token = {
 
 @pytest.mark.asyncio
 async def test_refresh_token():
-    def verifier(request):
+    async def verifier(request):
+        content = await request.body()
         if str(request.url) == 'https://i.b/token':
-            assert b'assertion=' in request.read()
+            assert b'assertion=' in content
 
     async with AsyncAssertionClient(
         'https://i.b/token',
@@ -27,7 +28,7 @@ async def test_refresh_token():
         audience='foo',
         alg='HS256',
         key='secret',
-        dispatch=MockDispatch(default_token, assert_func=verifier)
+        app=MockDispatch(default_token, assert_func=verifier)
     ) as client:
         await client.get('https://i.b')
 
@@ -44,7 +45,7 @@ async def test_refresh_token():
         key='secret',
         scope='email',
         claims={'test_mode': 'true'},
-        dispatch=MockDispatch(default_token, assert_func=verifier)
+        app=MockDispatch(default_token, assert_func=verifier)
     ) as client:
         await client.get('https://i.b')
         await client.get('https://i.b')

--- a/tests/py3/test_starlette_client/test_oauth_client.py
+++ b/tests/py3/test_starlette_client/test_oauth_client.py
@@ -39,7 +39,7 @@ def test_register_with_overwrite():
 @pytest.mark.asyncio
 async def test_oauth1_authorize():
     oauth = OAuth()
-    dispatch = PathMapDispatch({
+    app = PathMapDispatch({
         '/request-token': {'body': 'oauth_token=foo&oauth_verifier=baz'},
         '/token': {'body': 'oauth_token=a&oauth_token_secret=b'},
     })
@@ -52,7 +52,7 @@ async def test_oauth1_authorize():
         access_token_url='https://i.b/token',
         authorize_url='https://i.b/authorize',
         client_kwargs={
-            'dispatch': dispatch,
+            'app': app,
         }
     )
 
@@ -73,7 +73,7 @@ async def test_oauth1_authorize():
 @pytest.mark.asyncio
 async def test_oauth2_authorize():
     oauth = OAuth()
-    dispatch = PathMapDispatch({
+    app = PathMapDispatch({
         '/token': {'body': get_bearer_token()}
     })
     client = oauth.register(
@@ -84,7 +84,7 @@ async def test_oauth2_authorize():
         access_token_url='https://i.b/token',
         authorize_url='https://i.b/authorize',
         client_kwargs={
-            'dispatch': dispatch,
+            'app': app,
         }
     )
 
@@ -112,7 +112,7 @@ async def test_oauth2_authorize():
 
 @pytest.mark.asyncio
 async def test_oauth2_authorize_code_challenge():
-    dispatch = PathMapDispatch({
+    app = PathMapDispatch({
         '/token': {'body': get_bearer_token()}
     })
     oauth = OAuth()
@@ -124,7 +124,7 @@ async def test_oauth2_authorize_code_challenge():
         authorize_url='https://i.b/authorize',
         client_kwargs={
             'code_challenge_method': 'S256',
-            'dispatch': dispatch,
+            'app': app,
         },
     )
 
@@ -162,7 +162,7 @@ async def test_with_fetch_token_in_register():
     async def fetch_token(request):
         return {'access_token': 'dev', 'token_type': 'bearer'}
 
-    dispatch = PathMapDispatch({
+    app = PathMapDispatch({
         '/user': {'body': {'sub': '123'}}
     })
     oauth = OAuth()
@@ -175,7 +175,7 @@ async def test_with_fetch_token_in_register():
         authorize_url='https://i.b/authorize',
         fetch_token=fetch_token,
         client_kwargs={
-            'dispatch': dispatch,
+            'app': app,
         }
     )
 
@@ -190,7 +190,7 @@ async def test_with_fetch_token_in_oauth():
     async def fetch_token(name, request):
         return {'access_token': 'dev', 'token_type': 'bearer'}
 
-    dispatch = PathMapDispatch({
+    app = PathMapDispatch({
         '/user': {'body': {'sub': '123'}}
     })
     oauth = OAuth(fetch_token=fetch_token)
@@ -202,7 +202,7 @@ async def test_with_fetch_token_in_oauth():
         access_token_url='https://i.b/token',
         authorize_url='https://i.b/authorize',
         client_kwargs={
-            'dispatch': dispatch,
+            'app': app,
         }
     )
 
@@ -215,7 +215,7 @@ async def test_with_fetch_token_in_oauth():
 @pytest.mark.asyncio
 async def test_request_withhold_token():
     oauth = OAuth()
-    dispatch = PathMapDispatch({
+    app = PathMapDispatch({
         '/user': {'body': {'sub': '123'}}
     })
     client = oauth.register(
@@ -226,7 +226,7 @@ async def test_request_withhold_token():
         access_token_url="https://i.b/token",
         authorize_url="https://i.b/authorize",
         client_kwargs={
-            'dispatch': dispatch,
+            'app': app,
         }
     )
     req_scope = {'type': 'http', 'session': {}}
@@ -251,7 +251,7 @@ async def test_oauth2_authorize_with_metadata():
         await client.create_authorization_url(req)
 
 
-    dispatch = PathMapDispatch({
+    app = PathMapDispatch({
         '/.well-known/openid-configuration': {'body': {
             'authorization_endpoint': 'https://i.b/authorize'
         }}
@@ -264,7 +264,7 @@ async def test_oauth2_authorize_with_metadata():
         access_token_url='https://i.b/token',
         server_metadata_url='https://i.b/.well-known/openid-configuration',
         client_kwargs={
-            'dispatch': dispatch,
+            'app': app,
         }
     )
     resp = await client.authorize_redirect(req, 'https://b.com/bar')

--- a/tests/py3/test_starlette_client/test_user_mixin.py
+++ b/tests/py3/test_starlette_client/test_user_mixin.py
@@ -15,7 +15,7 @@ async def run_fetch_userinfo(payload, compliance_fix=None):
     async def fetch_token(request):
         return get_bearer_token()
 
-    dispatch = PathMapDispatch({
+    app = PathMapDispatch({
         '/userinfo': {'body': payload}
     })
 
@@ -27,7 +27,7 @@ async def run_fetch_userinfo(payload, compliance_fix=None):
         userinfo_endpoint='https://i.b/userinfo',
         userinfo_compliance_fix=compliance_fix,
         client_kwargs={
-            'dispatch': dispatch,
+            'app': app,
         }
     )
 
@@ -125,7 +125,7 @@ async def test_force_fetch_jwks_uri():
         aud='dev', exp=3600, nonce='n',
     )
 
-    dispatch = PathMapDispatch({
+    app = PathMapDispatch({
         '/jwks': {'body': read_file_path('jwks_public.json')}
     })
 
@@ -138,7 +138,7 @@ async def test_force_fetch_jwks_uri():
         jwks_uri='https://i.b/jwks',
         issuer='https://i.b',
         client_kwargs={
-            'dispatch': dispatch,
+            'app': app,
         }
     )
 


### PR DESCRIPTION
A couple of changes here to start to make sure that authlib only imports from the httpx public API...

* Import `Request`/`Response` from the top-level API.
* Switch to using `httpx.AsyncClient(app=...)` instead of relying on the undocumented dispatch API.

I still need to look at the usage of the ContentStreams API and figure out if https://github.com/encode/httpx/pull/932/files is the right approach, or if there's already sufficient public API here, and the auth flow just need re-jigging.

---

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

(If no, please delete the above question and this text message.)

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
