### PR TITLE
Drop usage of private httpx ContentStreams

### DIFF
--- a/authlib/integrations/httpx_client/oauth1_client.py
+++ b/authlib/integrations/httpx_client/oauth1_client.py
@@ -7,7 +7,7 @@ from authlib.oauth1 import (
 from authlib.common.encoding import to_unicode
 from authlib.oauth1 import ClientAuth
 from authlib.oauth1.client import OAuth1Client as _OAuth1Client
-from .utils import extract_client_kwargs, rebuild_request
+from .utils import extract_client_kwargs
 from ..base_client import OAuthError
 
 
@@ -18,7 +18,7 @@ class OAuth1Auth(Auth, ClientAuth):
     def auth_flow(self, request: Request) -> typing.Generator[Request, Response, None]:
         url, headers, body = self.prepare(
             request.method, str(request.url), request.headers, request.content)
-        yield rebuild_request(request, url, headers, body)
+        yield Request(method=request.method, url=url, headers=headers, data=body)
 
 
 class AsyncOAuth1Client(_OAuth1Client, AsyncClient):

--- a/authlib/integrations/httpx_client/oauth2_client.py
+++ b/authlib/integrations/httpx_client/oauth2_client.py
@@ -3,7 +3,7 @@ from httpx import AsyncClient, Auth, Request, Response
 from authlib.common.urls import url_decode
 from authlib.oauth2.client import OAuth2Client as _OAuth2Client
 from authlib.oauth2.auth import ClientAuth, TokenAuth
-from .utils import HTTPX_CLIENT_KWARGS, rebuild_request
+from .utils import HTTPX_CLIENT_KWARGS
 from ..base_client import (
     OAuthError,
     InvalidTokenError,
@@ -25,7 +25,7 @@ class OAuth2Auth(Auth, TokenAuth):
         try:
             url, headers, body = self.prepare(
                 str(request.url), request.headers, request.content)
-            yield rebuild_request(request, url, headers, body)
+            yield Request(method=request.method, url=url, headers=headers, data=body)
         except KeyError as error:
             description = 'Unsupported token_type: {}'.format(str(error))
             raise UnsupportedTokenTypeError(description=description)
@@ -37,7 +37,7 @@ class OAuth2ClientAuth(Auth, ClientAuth):
     def auth_flow(self, request: Request) -> typing.Generator[Request, Response, None]:
         url, headers, body = self.prepare(
             request.method, str(request.url), request.headers, request.content)
-        yield rebuild_request(request, url, headers, body)
+        yield Request(method=request.method, url=url, headers=headers, data=body)
 
 
 class AsyncOAuth2Client(_OAuth2Client, AsyncClient):

--- a/authlib/integrations/httpx_client/utils.py
+++ b/authlib/integrations/httpx_client/utils.py
@@ -1,5 +1,3 @@
-from httpx import URL
-from httpx.content_streams import ByteStream
 from authlib.common.encoding import to_bytes
 
 
@@ -17,14 +15,3 @@ def extract_client_kwargs(kwargs):
         if k in kwargs:
             client_kwargs[k] = kwargs.pop(k)
     return client_kwargs
-
-
-def rebuild_request(request, url, headers, body):
-    request.url = URL(url)
-    request.headers.update(headers)
-    if body:
-        body = to_bytes(body)
-        if body != request.content:
-            request._content = body
-            request.stream = ByteStream(body)
-    return request

--- a/tests/py3/test_httpx_client/test_async_oauth1_client.py
+++ b/tests/py3/test_httpx_client/test_async_oauth1_client.py
@@ -115,7 +115,13 @@ async def test_get_via_header():
 
 @pytest.mark.asyncio
 async def test_get_via_body():
-    mock_response = MockDispatch(b'hello')
+    async def assert_func(request):
+        content = await request.body()
+        assert b'oauth_token=foo' in content
+        assert b'oauth_consumer_key=id' in content
+        assert b'oauth_signature=' in content
+
+    mock_response = MockDispatch(b'hello', assert_func=assert_func)
     async with AsyncOAuth1Client(
         'id', 'secret', token='foo', token_secret='bar',
         signature_type=SIGNATURE_TYPE_BODY,
@@ -128,10 +134,6 @@ async def test_get_via_body():
     request = response.request
     auth_header = request.headers.get('authorization')
     assert auth_header is None
-
-    assert b'oauth_token=foo' in request.content
-    assert b'oauth_consumer_key=id' in request.content
-    assert b'oauth_signature=' in request.content
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Rejig the auth flow slightly, so as to not rely on `httpx`'s private `ContentStreams`.

After this fix I believe authlib should be compatible with `httpx` 0.12, the upcoming 0.13, and the planned 1.x series.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

(If no, please delete the above question and this text message.)

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
