### PR TITLE
Remove token checking before load_server_metadata

### DIFF
--- a/authlib/integrations/base_client/async_app.py
+++ b/authlib/integrations/base_client/async_app.py
@@ -110,7 +110,7 @@ class AsyncRemoteApp(BaseApp):
             url = urlparse.urljoin(self.api_base_url, url)
 
         withhold_token = kwargs.get('withhold_token')
-        if token and not withhold_token:
+        if not withhold_token:
             metadata = await self.load_server_metadata()
         else:
             metadata = {}

--- a/authlib/integrations/base_client/remote_app.py
+++ b/authlib/integrations/base_client/remote_app.py
@@ -115,7 +115,7 @@ class RemoteApp(BaseApp):
             url = urlparse.urljoin(self.api_base_url, url)
 
         withhold_token = kwargs.get('withhold_token')
-        if token and not withhold_token:
+        if not withhold_token:
             metadata = self.load_server_metadata()
         else:
             metadata = {}


### PR DESCRIPTION
> DO NOT SEND ANY SECURITY FIX HERE. Please read "Security Reporting" section
> on README.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

The problem happens if server_metadata_url is used instead of manual passing access_token_url and token is not passed to request but via fetch_token callback registered in OAuth. When the token expires, and an OAuth resource is requested by invoking request/get/put, loader_server_metadata is skipped because token is not manually passed in (token=None). Thus, metadata is empty, OAuth2Auth.ensure_active_token() is unable to get token_endpoint, hence unable to refresh token, resulting in invalid token exception.

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
