### PR TITLE
Remove deprecated and purely documentational argument providing_args in Django integrations

### DIFF
--- a/authlib/integrations/django_client/integration.py
+++ b/authlib/integrations/django_client/integration.py
@@ -5,7 +5,7 @@ from ..base_client import FrameworkIntegration, RemoteApp
 from ..requests_client import OAuth1Session, OAuth2Session
 
 
-token_update = Signal(providing_args=['name', 'token', 'refresh_token', 'access_token'])
+token_update = Signal()
 
 
 class DjangoIntegration(FrameworkIntegration):

--- a/authlib/integrations/django_oauth2/signals.py
+++ b/authlib/integrations/django_oauth2/signals.py
@@ -2,10 +2,10 @@ from django.dispatch import Signal
 
 
 #: signal when client is authenticated
-client_authenticated = Signal(providing_args=['client', 'grant'])
+client_authenticated = Signal()
 
 #: signal when token is revoked
-token_revoked = Signal(providing_args=['token', 'client'])
+token_revoked = Signal()
 
 #: signal when token is authenticated
-token_authenticated = Signal(providing_args=['token'])
+token_authenticated = Signal()


### PR DESCRIPTION
In Django 3.1 the purely documentational feature of sending in `providing_args` when creating a `Signal` was deprecated:
https://docs.djangoproject.com/en/3.1/releases/3.1/#id2
> The purely documentational providing_args argument for Signal is deprecated. If you rely on this argument as documentation, you can move the text to a code comment or docstring.

This removes the argument so that we don't get deprecation warnings.

The feature has been purely documentational since 1.8 so this shouldn't break anybody's code.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
