### PR TITLE
Fix test if authorization should be provided to the underlying httpx client

### DIFF
--- a/authlib/integrations/httpx_client/oauth2_client.py
+++ b/authlib/integrations/httpx_client/oauth2_client.py
@@ -1,6 +1,6 @@
 import asyncio
 import typing
-from httpx import AsyncClient, Auth, Request, Response
+from httpx import AsyncClient, Auth, Request, Response, _config
 from authlib.common.urls import url_decode
 from authlib.oauth2.client import OAuth2Client as _OAuth2Client
 from authlib.oauth2.auth import ClientAuth, TokenAuth
@@ -78,7 +78,7 @@ class AsyncOAuth2Client(_OAuth2Client, AsyncClient):
         raise OAuthError(error_type, error_description)
 
     async def request(self, method, url, withhold_token=False, auth=None, **kwargs):
-        if not withhold_token and auth is None:
+        if not withhold_token and auth in (None, _config.UNSET):
             if not self.token:
                 raise MissingTokenError()
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes, for users of very old HTTPX version (0.11.x)
- [ ] No

In HTTPX 0.11.x `auth` argument to the `AsyncClient.request` had `None` as default. Since 0.12 default is changed to a sentinel object of type `UnsetType`. Users should upgrade their HTTPX version. 

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.


We are using HTTPX 0.14 and faced the issue when authlib's `AsyncOauth2Client` had a token but never provided it to the underlying client because `auth` argument to `AsyncOauth2Client.request` method always had a value of `httpx._config.UNSET` and not `None` (code expects it to be `None`). 

HTTPX version 0.14.3
Authlib version 0.14.3