### PR TITLE
Fix claims.py to support decimal values of `auth_time` claim

### DIFF
--- a/authlib/oidc/core/claims.py
+++ b/authlib/oidc/core/claims.py
@@ -56,7 +56,7 @@ class IDToken(JWTClaims):
         if self.params.get('max_age') and not auth_time:
             raise MissingClaimError('auth_time')
 
-        if auth_time and not (isinstance(auth_time, int) or isinstance(auth_time, float)):
+        if auth_time and not isinstance(auth_time, (int, float)):
             raise InvalidClaimError('auth_time')
 
     def validate_nonce(self):

--- a/authlib/oidc/core/claims.py
+++ b/authlib/oidc/core/claims.py
@@ -56,7 +56,7 @@ class IDToken(JWTClaims):
         if self.params.get('max_age') and not auth_time:
             raise MissingClaimError('auth_time')
 
-        if auth_time and not isinstance(auth_time, int):
+        if auth_time and not (isinstance(auth_time, int) or isinstance(auth_time, float)):
             raise InvalidClaimError('auth_time')
 
     def validate_nonce(self):


### PR DESCRIPTION
according to spec 'auth_time' is JSON NUMBER which can be decimal

fixe #309

> DO NOT SEND ANY SECURITY FIX HERE. Please read "Security Reporting" section
> on README.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

(If no, please delete the above question and this text message.)

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
