### PR TITLE
Improve support for non-expiring oauth tokens

### DIFF
--- a/authlib/oauth2/rfc6750/token.py
+++ b/authlib/oauth2/rfc6750/token.py
@@ -73,8 +73,9 @@ class BearerTokenGenerator(object):
         token = {
             'token_type': 'Bearer',
             'access_token': access_token,
-            'expires_in': expires_in
         }
+        if expires_in:
+            token['expires_in'] = expires_in
         if include_refresh_token and self.refresh_token_generator:
             token['refresh_token'] = self.refresh_token_generator(
                 client=client, grant_type=grant_type, user=user, scope=scope)


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Feature (closes #311)

**Does this PR introduce a breaking change?** (check one)

- [x] No

The `expires_in` column already defaults to `0` and the `is_expired` method assumes a token with a falsy `expires_in` is never expired. The only thing this PR changes is not sending a misleading `expires_in: 0` (which sounds more like a token that immediately expired!) in this case.

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.