### PR TITLE
Add documentation for manually refreshing users tokens

### DIFF
--- a/docs/client/django.rst
+++ b/docs/client/django.rst
@@ -125,6 +125,22 @@ it is also possible to use signal to listen for token updating::
         item.save()
 
 
+Manually Refreshing Expired Token
+----------------------------
+When not actively making requests using the Authlib client. You may
+need to refresh a users access token. This can be done by by accessing 
+your client,  manually exchanging the refresh token, and then updating
+the stored token::
+
+    new_token = oauth.google.fetch_access_token(
+        redirect_uri=redirect_uri,
+        refresh_token=refresh_token,
+        grant_type="refresh_token",
+    )
+
+    update_token(name, new_token, refresh_token=refresh_token)
+
+
 Django OpenID Connect Client
 ----------------------------
 


### PR DESCRIPTION
> DO NOT SEND ANY SECURITY FIX HERE. Please read "Security Reporting" section
> on README.

We are migrating to Authlib and are still using our old client in some areas of the application. There is no documentation for manually refreshing tokens using Authlib when needed. I suggest adding something like the following.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

(If no, please delete the above question and this text message.)

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
