### PR TITLE
Use resp.raise_for_status() before using resp.json().

### DIFF
--- a/authlib/integrations/base_client/async_app.py
+++ b/authlib/integrations/base_client/async_app.py
@@ -74,6 +74,7 @@ class AsyncOAuth2Mixin(OAuth2Base):
         if self._server_metadata_url and '_loaded_at' not in self.server_metadata:
             async with self.client_cls(**self.client_kwargs) as client:
                 resp = await client.request('GET', self._server_metadata_url, withhold_token=True)
+                resp.raise_for_status()
                 metadata = resp.json()
                 metadata['_loaded_at'] = time.time()
             self.server_metadata.update(metadata)

--- a/authlib/integrations/base_client/async_openid.py
+++ b/authlib/integrations/base_client/async_openid.py
@@ -17,6 +17,7 @@ class AsyncOpenIDMixin(object):
 
         async with self.client_cls(**self.client_kwargs) as client:
             resp = await client.request('GET', uri, withhold_token=True)
+            resp.raise_for_status()
             jwk_set = resp.json()
 
         self.server_metadata['jwks'] = jwk_set
@@ -26,6 +27,7 @@ class AsyncOpenIDMixin(object):
         """Fetch user info from ``userinfo_endpoint``."""
         metadata = await self.load_server_metadata()
         resp = await self.get(metadata['userinfo_endpoint'], **kwargs)
+        resp.raise_for_status()
         data = resp.json()
         return UserInfo(data)
 

--- a/authlib/integrations/base_client/sync_app.py
+++ b/authlib/integrations/base_client/sync_app.py
@@ -292,6 +292,7 @@ class OAuth2Mixin(_RequestMixin, OAuth2Base):
         if self._server_metadata_url and '_loaded_at' not in self.server_metadata:
             with self.client_cls(**self.client_kwargs) as session:
                 resp = session.request('GET', self._server_metadata_url, withhold_token=True)
+                resp.raise_for_status()
                 metadata = resp.json()
 
             metadata['_loaded_at'] = time.time()

--- a/authlib/integrations/base_client/sync_openid.py
+++ b/authlib/integrations/base_client/sync_openid.py
@@ -15,6 +15,7 @@ class OpenIDMixin(object):
 
         with self.client_cls(**self.client_kwargs) as session:
             resp = session.request('GET', uri, withhold_token=True)
+            resp.raise_for_status()
             jwk_set = resp.json()
 
         self.server_metadata['jwks'] = jwk_set
@@ -24,6 +25,7 @@ class OpenIDMixin(object):
         """Fetch user info from ``userinfo_endpoint``."""
         metadata = self.load_server_metadata()
         resp = self.get(metadata['userinfo_endpoint'], **kwargs)
+        resp.raise_for_status()
         data = resp.json()
         return UserInfo(data)
 

--- a/authlib/integrations/httpx_client/assertion_client.py
+++ b/authlib/integrations/httpx_client/assertion_client.py
@@ -47,6 +47,7 @@ class AsyncAssertionClient(_AssertionClient, AsyncClient):
         resp = await self.request(
             'POST', self.token_endpoint, data=data, withhold_token=True)
 
+        resp.raise_for_status()
         token = resp.json()
         if 'error' in token:
             raise OAuth2Error(

--- a/authlib/integrations/httpx_client/oauth2_client.py
+++ b/authlib/integrations/httpx_client/oauth2_client.py
@@ -130,6 +130,7 @@ class AsyncOAuth2Client(_OAuth2Client, AsyncClient):
         for hook in self.compliance_hook['access_token_response']:
             resp = hook(resp)
 
+        resp.raise_for_status()
         return self.parse_response_token(resp.json())
 
     async def _refresh_token(self, url, refresh_token=None, body='',
@@ -141,6 +142,7 @@ class AsyncOAuth2Client(_OAuth2Client, AsyncClient):
         for hook in self.compliance_hook['refresh_token_response']:
             resp = hook(resp)
 
+        resp.raise_for_status()
         token = self.parse_response_token(resp.json())
         if 'refresh_token' not in token:
             self.token['refresh_token'] = refresh_token

--- a/authlib/oauth2/client.py
+++ b/authlib/oauth2/client.py
@@ -348,6 +348,7 @@ class OAuth2Client(object):
         for hook in self.compliance_hook['access_token_response']:
             resp = hook(resp)
 
+        resp.raise_for_status()
         return self.parse_response_token(resp.json())
 
     def _refresh_token(self, url, refresh_token=None, body='', headers=None,
@@ -357,6 +358,7 @@ class OAuth2Client(object):
         for hook in self.compliance_hook['refresh_token_response']:
             resp = hook(resp)
 
+        resp.raise_for_status()
         token = self.parse_response_token(resp.json())
         if 'refresh_token' not in token:
             self.token['refresh_token'] = refresh_token

--- a/authlib/oauth2/rfc7521/client.py
+++ b/authlib/oauth2/rfc7521/client.py
@@ -73,6 +73,7 @@ class AssertionClient(object):
         resp = self.session.request(
             'POST', self.token_endpoint, data=data, withhold_token=True)
 
+        resp.raise_for_status()
         token = resp.json()
         if 'error' in token:
             raise OAuth2Error(

--- a/authlib/oauth2/rfc7662/token_validator.py
+++ b/authlib/oauth2/rfc7662/token_validator.py
@@ -19,6 +19,7 @@ class IntrospectTokenValidator(TokenValidator):
                 # authentication.
                 url = 'https://example.com/oauth/introspect'
                 resp = requests.post(url, data={'token': token_string})
+                resp.raise_for_status()
                 return resp.json()
         """
         raise NotImplementedError()

--- a/docs/client/flask.rst
+++ b/docs/client/flask.rst
@@ -126,6 +126,7 @@ into routes. In this case, the routes for authorization should look like::
     def authorize():
         token = oauth.twitter.authorize_access_token()
         resp = oauth.twitter.get('account/verify_credentials.json')
+        resp.raise_for_status()
         profile = resp.json()
         # do something with the token and profile
         return redirect('/')
@@ -142,6 +143,7 @@ automatically::
     @app.route('/github')
     def show_github_profile():
         resp = oauth.github.get('user')
+        resp.raise_for_status()
         profile = resp.json()
         return render_template('github.html', profile=profile)
 

--- a/docs/client/frameworks.rst
+++ b/docs/client/frameworks.rst
@@ -123,6 +123,7 @@ Here is the example for Twitter login::
         twitter = oauth.create_client('twitter')
         token = twitter.authorize_access_token(request)
         resp = twitter.get('account/verify_credentials.json')
+        resp.raise_for_status()
         profile = resp.json()
         # do something with the token and profile
         return '...'
@@ -202,6 +203,7 @@ Here is the example for GitHub login::
     def authorize(request):
         token = oauth.github.authorize_access_token(request)
         resp = oauth.github.get('user', token=token)
+        resp.raise_for_status()
         profile = resp.json()
         # do something with the token and profile
         return '...'
@@ -277,6 +279,7 @@ in user's twitter time line and GitHub repositories. You will use
         )
         # API URL: https://api.twitter.com/1.1/statuses/user_timeline.json
         resp = oauth.twitter.get('statuses/user_timeline.json', token=token.to_token())
+        resp.raise_for_status()
         return resp.json()
 
     def get_github_repositories(request):
@@ -286,6 +289,7 @@ in user's twitter time line and GitHub repositories. You will use
         )
         # API URL: https://api.github.com/user/repos
         resp = oauth.github.get('user/repos', token=token.to_token())
+        resp.raise_for_status()
         return resp.json()
 
 In this case, we need a place to store the access token in order to use
@@ -408,6 +412,7 @@ instead, they can pass the ``request``::
 
     def get_twitter_tweets(request):
         resp = oauth.twitter.get('statuses/user_timeline.json', request=request)
+        resp.raise_for_status()
         return resp.json()
 
 
@@ -479,6 +484,7 @@ a method to fix the requests session::
 
     def slack_compliance_fix(session):
         def _fix(resp):
+            resp.raise_for_status()
             token = resp.json()
             # slack returns no token_type
             token['token_type'] = 'Bearer'

--- a/docs/specs/rfc7662.rst
+++ b/docs/specs/rfc7662.rst
@@ -91,6 +91,7 @@ endpoint to validate the given token. Here is how::
             data = {'token': token_string, 'token_type_hint': 'access_token'}
             auth = (secrets.internal_client_id, secrets.internal_client_secret)
             resp = requests.post(url, data=data, auth=auth)
+            resp.raise_for_status()
             return resp.json()
 
 We can then register this token validator in to resource protector::


### PR DESCRIPTION
It is better to raise an exception due to an HTTP error status rather
than an error like the following which may be received due to a 502 Bad
Gateway which returns HTML content, for example.

json.decoder.JSONDecodeError: Expecting value: line 2 column 1 (char 1)

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
