### PR TITLE
Add the Token and Resource Scope to the InsufficientScopeError

### DIFF
--- a/authlib/oauth2/rfc6750/errors.py
+++ b/authlib/oauth2/rfc6750/errors.py
@@ -78,8 +78,14 @@ class InsufficientScopeError(OAuth2Error):
     error = 'insufficient_scope'
     status_code = 403
 
+    def __init__(self, token_scope, resource_scope):
+        super(InsufficientScopeError, self).__init__()
+        self.token_scope = token_scope
+        self.resource_scope = resource_scope
+
     def get_error_description(self):
         return self.gettext(
             'The request requires higher privileges than '
-            'provided by the access token.'
-        )
+            'provided by the access token. '
+            'Required: "%(required)s", Provided:"%(provided)s"'
+        )  % dict(required=self.resource_scope, provided=self.token_scope)

--- a/authlib/oauth2/rfc6750/validator.py
+++ b/authlib/oauth2/rfc6750/validator.py
@@ -95,5 +95,5 @@ class BearerTokenValidator(object):
         if self.token_revoked(token):
             raise InvalidTokenError(realm=self.realm)
         if self.scope_insufficient(token, scope, scope_operator):
-            raise InsufficientScopeError()
+            raise InsufficientScopeError(token_scope=token.get_scope(), resource_scope=scope)
         return token


### PR DESCRIPTION
We have a product requirement to include the token and resource scopes on an InsufficientScopeError. We could override this in our own code, but thought it might be useful here too.

I know 0.15 is in maintenance mode, but until 1.0.0 is released we are stuck on it. I can also put up a similar PR to 1.0.0 if this one is approved.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [] No
- [X] Maybe?

If yes, please describe the impact and migration path for existing applications:
I am changing the error text for the InsufficientScopeError which could result in the wrong translations. Not really breaking, but could cause problems?

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.