### PR TITLE
Fix issue with long client secrets

### DIFF
--- a/authlib/oauth2/auth.py
+++ b/authlib/oauth2/auth.py
@@ -7,7 +7,7 @@ from .rfc6750 import add_bearer_token
 
 def encode_client_secret_basic(client, method, uri, headers, body):
     text = '{}:{}'.format(client.client_id, client.client_secret)
-    auth = to_native(base64.urlsafe_b64encode(to_bytes(text, 'latin1')))
+    auth = to_native(base64.b64encode(to_bytes(text, 'latin1')))
     headers['Authorization'] = 'Basic {}'.format(auth)
     return uri, headers, body
 


### PR DESCRIPTION
Don't use urlsafe base64 encoding for client_secret_basic authorization headers because it doesn't play well with extraction of the authorization of certain client_secrets. 

Should fix #187

> DO NOT SEND ANY SECURITY FIX HERE. Please read "Security Reporting" section
> on README.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
