### PR TITLE
Do not send state on fetch token

### DIFF
--- a/authlib/oauth2/client.py
+++ b/authlib/oauth2/client.py
@@ -154,7 +154,7 @@ class OAuth2Client(object):
         return uri, state
 
     def fetch_token(self, url=None, body='', method='POST', headers=None,
-                    auth=None, grant_type=None, **kwargs):
+                    auth=None, grant_type=None, state=None, **kwargs):
         """Generic method for fetching an access token from the token endpoint.
 
         :param url: Access Token endpoint URL, if not configured,
@@ -173,7 +173,7 @@ class OAuth2Client(object):
         # implicit  grant_type
         authorization_response = kwargs.pop('authorization_response', None)
         if authorization_response and '#' in authorization_response:
-            return self.token_from_fragment(authorization_response, kwargs.get('state'))
+            return self.token_from_fragment(authorization_response, state)
 
         session_kwargs = self._extract_session_request_params(kwargs)
 
@@ -181,7 +181,7 @@ class OAuth2Client(object):
             grant_type = 'authorization_code'
             params = parse_authorization_code_response(
                 authorization_response,
-                state=kwargs.get('state'),
+                state=state,
             )
             kwargs['code'] = params['code']
 


### PR DESCRIPTION
A fetch token request includes `state` value which is already consumed by`parse_authorization_code_response`. I validate a fetch token request very strictly, and don't want to get this field.

---

> DO NOT SEND ANY SECURITY FIX HERE. Please read "Security Reporting" section
> on README.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
