### PR TITLE
Use Request(content=...) for string content in httpx

### DIFF
--- a/authlib/integrations/httpx_client/oauth1_client.py
+++ b/authlib/integrations/httpx_client/oauth1_client.py
@@ -19,7 +19,7 @@ class OAuth1Auth(Auth, ClientAuth):
         url, headers, body = self.prepare(
             request.method, str(request.url), request.headers, request.content)
         headers['Content-Length'] = str(len(body))
-        yield Request(method=request.method, url=url, headers=headers, data=body)
+        yield Request(method=request.method, url=url, headers=headers, content=body)
 
 
 class AsyncOAuth1Client(_OAuth1Client, AsyncClient):

--- a/authlib/integrations/httpx_client/oauth2_client.py
+++ b/authlib/integrations/httpx_client/oauth2_client.py
@@ -31,7 +31,7 @@ class OAuth2Auth(Auth, TokenAuth):
             url, headers, body = self.prepare(
                 str(request.url), request.headers, request.content)
             headers['Content-Length'] = str(len(body))
-            yield Request(method=request.method, url=url, headers=headers, data=body)
+            yield Request(method=request.method, url=url, headers=headers, content=body)
         except KeyError as error:
             description = 'Unsupported token_type: {}'.format(str(error))
             raise UnsupportedTokenTypeError(description=description)
@@ -43,7 +43,7 @@ class OAuth2ClientAuth(Auth, ClientAuth):
     def auth_flow(self, request: Request) -> typing.Generator[Request, Response, None]:
         url, headers, body = self.prepare(
             request.method, str(request.url), request.headers, request.content)
-        yield Request(method=request.method, url=url, headers=headers, data=body)
+        yield Request(method=request.method, url=url, headers=headers, content=body)
 
 
 class AsyncOAuth2Client(_OAuth2Client, AsyncClient):


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Other, please describe: **fix deprecation warning from httpx**

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No **(unless people are using httpx < 0.15.0, which is relatively old)**

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.

---

Authlib raises deprecation warnings when used with the latest version of httpx.

This is because authlib uses the `Request(data="foo", ...)` syntax for string content, which is [deprecated](https://github.com/encode/httpx/pull/1573) as of httpx 0.18.0 (April 2021) in favour of `Request(content="foo", ...)` [introduced](https://github.com/encode/httpx/blob/master/CHANGELOG.md#0150-september-22nd-2020) in httpx 0.15.0 (September 2020).

This PR updates authlib to use the new syntax when the content is a string. (When the content is a dict, we still use `data=`.)