### PR TITLE
Fix method signatures for _HTTPException

### DIFF
--- a/authlib/integrations/flask_oauth2/errors.py
+++ b/authlib/integrations/flask_oauth2/errors.py
@@ -9,10 +9,10 @@ class _HTTPException(HTTPException):
         self.body = body
         self.headers = headers
 
-    def get_body(self, environ=None):
+    def get_body(self, environ=None, scope=None):
         return self.body
 
-    def get_headers(self, environ=None):
+    def get_headers(self, environ=None, scope=None):
         return self.headers
 
 


### PR DESCRIPTION
werkzeug 2 [changed](https://github.com/pallets/werkzeug/commit/97ced0954d07e03c435d69a3fbc5d5b48c60260a#diff-3877eb97aaf29390c157ea087f3001ea218637b107ab615ce154b18546e45c3fL157) its HTTPException method signatures. This PR makes authlib compatible with the updated signatures.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
