### PR TITLE
Use request.build_absolute_uri instead of request.get_raw_uri

### DIFF
--- a/authlib/integrations/django_helpers.py
+++ b/authlib/integrations/django_helpers.py
@@ -13,5 +13,5 @@ def create_oauth_request(request, request_cls, use_json=False):
     else:
         body = None
 
-    url = request.get_raw_uri()
+    url = request.build_absolute_uri()
     return request_cls(request.method, url, body, request.headers)

--- a/authlib/integrations/django_oauth1/resource_protector.py
+++ b/authlib/integrations/django_oauth1/resource_protector.py
@@ -42,7 +42,7 @@ class ResourceProtector(_ResourceProtector):
         else:
             body = None
 
-        url = request.get_raw_uri()
+        url = request.build_absolute_uri()
         req = self.validate_request(request.method, url, body, request.headers)
         return req.credential
 

--- a/authlib/integrations/django_oauth2/resource_protector.py
+++ b/authlib/integrations/django_oauth2/resource_protector.py
@@ -22,7 +22,7 @@ class ResourceProtector(_ResourceProtector):
         :param scopes: a list of scope values
         :return: token object
         """
-        url = request.get_raw_uri()
+        url = request.build_absolute_uri()
         req = HttpRequest(request.method, url, request.body, request.headers)
         req.req = request
         if isinstance(scopes, str):


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.

Django 4.0 removes the `request.get_raw_uri` method (https://code.djangoproject.com/ticket/32698). Switch to `request.build_absolute_uri` which should give the same result in regular cases.
