### PR TITLE
Backport httpx oauth2 client fixes to maintain-0.15 branch

### DIFF
--- a/authlib/integrations/httpx_client/oauth2_client.py
+++ b/authlib/integrations/httpx_client/oauth2_client.py
@@ -30,6 +30,7 @@ class OAuth2Auth(Auth, TokenAuth):
         try:
             url, headers, body = self.prepare(
                 str(request.url), request.headers, request.content)
+            headers['Content-Length'] = str(len(body))
             yield Request(method=request.method, url=url, headers=headers, data=body)
         except KeyError as error:
             description = 'Unsupported token_type: {}'.format(str(error))
@@ -42,6 +43,7 @@ class OAuth2ClientAuth(Auth, ClientAuth):
     def auth_flow(self, request: Request) -> typing.Generator[Request, Response, None]:
         url, headers, body = self.prepare(
             request.method, str(request.url), request.headers, request.content)
+        headers['Content-Length'] = str(len(body))
         yield Request(method=request.method, url=url, headers=headers, data=body)
 
 


### PR DESCRIPTION
> DO NOT SEND ANY SECURITY FIX HERE. Please read "Security Reporting" section
> on README.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.

I'd like to have the fixes of https://github.com/lepture/authlib/issues/335 backported to the `maintain-0.15` branch and ideally have a new bugfix release. This bug is inhibiting the use of https://github.com/lepture/authlib in our setup/use-case.
