### PR TITLE
allow to pass in alternative signing algoritm to RFC7523 JWT client assertions

### DIFF
--- a/authlib/oauth2/rfc7523/auth.py
+++ b/authlib/oauth2/rfc7523/auth.py
@@ -25,10 +25,13 @@ class ClientSecretJWT(object):
     :param claims: Extra JWT claims
     """
     name = 'client_secret_jwt'
+    alg = 'HS256'
 
-    def __init__(self, token_endpoint=None, claims=None):
+    def __init__(self, token_endpoint=None, claims=None, alg=None):
         self.token_endpoint = token_endpoint
         self.claims = claims
+        if alg is not None:
+            self.alg = alg
 
     def sign(self, auth, token_endpoint):
         return client_secret_jwt_sign(
@@ -36,6 +39,7 @@ class ClientSecretJWT(object):
             client_id=auth.client_id,
             token_endpoint=token_endpoint,
             claims=self.claims,
+            alg=self.alg,
         )
 
     def __call__(self, auth, method, uri, headers, body):
@@ -72,6 +76,7 @@ class PrivateKeyJWT(ClientSecretJWT):
     :param claims: Extra JWT claims
     """
     name = 'private_key_jwt'
+    alg = 'RS256'
 
     def sign(self, auth, token_endpoint):
         return private_key_jwt_sign(
@@ -79,6 +84,7 @@ class PrivateKeyJWT(ClientSecretJWT):
             client_id=auth.client_id,
             token_endpoint=token_endpoint,
             claims=self.claims,
+            alg=self.alg,
         )
 
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.

Referencing https://github.com/lepture/authlib/issues/389:

I'd like to have control over the signing algoritms used for the JWT client asserstion authentication variants. The current API doesn't allow to override the default RS256, even thought the lower-level signing helper functions are parameterized.

When setting up an PrivateKeyJWT() instance to register as client auth method, I'd like to pass in the signing algoritm I'd like to use.
