### PR TITLE
Allow passing in additionl jwt headers

### DIFF
--- a/authlib/oauth2/rfc7523/assertion.py
+++ b/authlib/oauth2/rfc7523/assertion.py
@@ -5,12 +5,11 @@ from authlib.common.security import generate_token
 
 def sign_jwt_bearer_assertion(
         key, issuer, audience, subject=None, issued_at=None,
-        expires_at=None, claims=None, header=None, **kwargs):
+        expires_at=None, alg=None, header=None, claims=None, **kwargs):
 
     if header is None:
         header = {}
-    alg = kwargs.pop('alg', None)
-    if alg:
+    if alg is not None:
         header['alg'] = alg
     if 'alg' not in header:
         raise ValueError('Missing "alg" in header')
@@ -38,13 +37,15 @@ def sign_jwt_bearer_assertion(
 
 
 def client_secret_jwt_sign(client_secret, client_id, token_endpoint, alg='HS256',
-                           claims=None, **kwargs):
-    return _sign(client_secret, client_id, token_endpoint, alg, claims, **kwargs)
+                           header=None, claims=None, **kwargs):
+    return _sign(client_secret, client_id, token_endpoint,
+                 alg, header=header, claims=claims, **kwargs)
 
 
 def private_key_jwt_sign(private_key, client_id, token_endpoint, alg='RS256',
-                         claims=None, **kwargs):
-    return _sign(private_key, client_id, token_endpoint, alg, claims, **kwargs)
+                         header=None, claims=None, **kwargs):
+    return _sign(private_key, client_id, token_endpoint,
+                 alg, header=header, claims=claims, **kwargs)
 
 
 def _sign(key, client_id, token_endpoint, alg, claims=None, **kwargs):

--- a/authlib/oauth2/rfc7523/auth.py
+++ b/authlib/oauth2/rfc7523/auth.py
@@ -27,8 +27,9 @@ class ClientSecretJWT(object):
     name = 'client_secret_jwt'
     alg = 'HS256'
 
-    def __init__(self, token_endpoint=None, claims=None, alg=None):
+    def __init__(self, token_endpoint=None, alg=None, header=None, claims=None):
         self.token_endpoint = token_endpoint
+        self.header = header
         self.claims = claims
         if alg is not None:
             self.alg = alg
@@ -38,8 +39,9 @@ class ClientSecretJWT(object):
             auth.client_secret,
             client_id=auth.client_id,
             token_endpoint=token_endpoint,
-            claims=self.claims,
             alg=self.alg,
+            header=self.header,
+            claims=self.claims,
         )
 
     def __call__(self, auth, method, uri, headers, body):
@@ -83,8 +85,9 @@ class PrivateKeyJWT(ClientSecretJWT):
             auth.client_secret,
             client_id=auth.client_id,
             token_endpoint=token_endpoint,
-            claims=self.claims,
             alg=self.alg,
+            header=self.header,
+            claims=self.claims,
         )
 
 

--- a/authlib/oauth2/rfc7523/auth.py
+++ b/authlib/oauth2/rfc7523/auth.py
@@ -25,10 +25,13 @@ class ClientSecretJWT(object):
     :param claims: Extra JWT claims
     """
     name = 'client_secret_jwt'
+    alg = 'HS256'
 
-    def __init__(self, token_endpoint=None, claims=None):
+    def __init__(self, token_endpoint=None, claims=None, alg=None):
         self.token_endpoint = token_endpoint
         self.claims = claims
+        if alg is not None:
+            self.alg = alg
 
     def sign(self, auth, token_endpoint):
         return client_secret_jwt_sign(
@@ -36,6 +39,7 @@ class ClientSecretJWT(object):
             client_id=auth.client_id,
             token_endpoint=token_endpoint,
             claims=self.claims,
+            alg=self.alg,
         )
 
     def __call__(self, auth, method, uri, headers, body):
@@ -72,6 +76,7 @@ class PrivateKeyJWT(ClientSecretJWT):
     :param claims: Extra JWT claims
     """
     name = 'private_key_jwt'
+    alg = 'RS256'
 
     def sign(self, auth, token_endpoint):
         return private_key_jwt_sign(
@@ -79,6 +84,7 @@ class PrivateKeyJWT(ClientSecretJWT):
             client_id=auth.client_id,
             token_endpoint=token_endpoint,
             claims=self.claims,
+            alg=self.alg,
         )
 
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.

Referencing https://github.com/lepture/authlib/issues/391

I'd like to pass in addtional JWT headers into the client assertion, such as the kid so the recipient of the token can find the corresponding key at the registered JWKS endpoint.

Describe the solution you'd like

When setting up an PrivateKeyJWT() instance to register as client auth method, I'd like to pass in additional JWT headers such as the kid.
