### PR TITLE
Fix compatibility with httpx >= 0.18.2

### DIFF
--- a/authlib/integrations/httpx_client/oauth2_client.py
+++ b/authlib/integrations/httpx_client/oauth2_client.py
@@ -1,10 +1,6 @@
 import asyncio
 import typing
-from httpx import AsyncClient, Auth, Client, Request, Response
-try:
-    from httpx._config import UNSET
-except ImportError:
-    UNSET = None
+from httpx import AsyncClient, Auth, Client, Request, Response, USE_CLIENT_DEFAULT
 from authlib.common.urls import url_decode
 from authlib.oauth2.client import OAuth2Client as _OAuth2Client
 from authlib.oauth2.auth import ClientAuth, TokenAuth
@@ -81,8 +77,8 @@ class AsyncOAuth2Client(_OAuth2Client, AsyncClient):
     def handle_error(error_type, error_description):
         raise OAuthError(error_type, error_description)
 
-    async def request(self, method, url, withhold_token=False, auth=UNSET, **kwargs):
-        if not withhold_token and auth is UNSET:
+    async def request(self, method, url, withhold_token=False, auth=USE_CLIENT_DEFAULT, **kwargs):
+        if not withhold_token and auth is USE_CLIENT_DEFAULT:
             if not self.token:
                 raise MissingTokenError()
 
@@ -114,7 +110,7 @@ class AsyncOAuth2Client(_OAuth2Client, AsyncClient):
             return
         await self._token_refresh_event.wait()  # wait until the token is ready
 
-    async def _fetch_token(self, url, body='', headers=None, auth=UNSET,
+    async def _fetch_token(self, url, body='', headers=None, auth=USE_CLIENT_DEFAULT,
                            method='POST', **kwargs):
         if method.upper() == 'POST':
             resp = await self.post(
@@ -133,7 +129,7 @@ class AsyncOAuth2Client(_OAuth2Client, AsyncClient):
         return self.parse_response_token(resp.json())
 
     async def _refresh_token(self, url, refresh_token=None, body='',
-                             headers=None, auth=UNSET, **kwargs):
+                             headers=None, auth=USE_CLIENT_DEFAULT, **kwargs):
         resp = await self.post(
             url, data=dict(url_decode(body)), headers=headers,
             auth=auth, **kwargs)
@@ -150,7 +146,7 @@ class AsyncOAuth2Client(_OAuth2Client, AsyncClient):
 
         return self.token
 
-    def _http_post(self, url, body=None, auth=UNSET, headers=None, **kwargs):
+    def _http_post(self, url, body=None, auth=USE_CLIENT_DEFAULT, headers=None, **kwargs):
         return self.post(
             url, data=dict(url_decode(body)),
             headers=headers, auth=auth, **kwargs)
@@ -187,8 +183,8 @@ class OAuth2Client(_OAuth2Client, Client):
     def handle_error(error_type, error_description):
         raise OAuthError(error_type, error_description)
 
-    def request(self, method, url, withhold_token=False, auth=UNSET, **kwargs):
-        if not withhold_token and auth is UNSET:
+    def request(self, method, url, withhold_token=False, auth=USE_CLIENT_DEFAULT, **kwargs):
+        if not withhold_token and auth is USE_CLIENT_DEFAULT:
             if not self.token:
                 raise MissingTokenError()
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

The httpx integration looses compatibility with httpx version 0.18.1 and lower.

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.

Replaced UNSET with USE_CLIENT_DEFAULT to ensure compatibility
of the AsyncOAuth2Client with httpx version 0.18.2 and greater.

Closes #377
