### PR TITLE
Fix httpx dependency

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -4,7 +4,7 @@ Flask
 Django
 SQLAlchemy
 requests
-httpx
+httpx>=0.18.2
 starlette
 Sphinx==4.3.0
 sphinx-typlog-theme==0.8.0


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

(If no, please delete the above question and this text message.)

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.

---

Currently authlib supports only httpx>=0.18.2. It fails with an error `ImportError: cannot import name 'USE_CLIENT_DEFAULT' from 'httpx' (/usr/local/lib/python3.9/site-packages/httpx/__init__.py)` when using with httpx 0.18.1.

## Issue:
- Pip dependency management does not work for authlib and httpx.

## Background:
- authlib has started using `USE_CLIENT_DEFAULT` on https://github.com/lepture/authlib/commit/40276708374fcc7c0ee6b1ce4955dbe7db82f5ba
- httpx has added  `USE_CLIENT_DEFAULT` at `httpx 0.18.2` as https://github.com/encode/httpx/pull/1634

## How to solve:
- Specify `httpx>=0.18.2` in the requirement txt.

