### PR TITLE
Use anyio.Lock to support trio/anyio backends in httpx client integrations

### DIFF
--- a/tests/starlette/test_httpx_client/test_async_oauth2_client.py
+++ b/tests/starlette/test_httpx_client/test_async_oauth2_client.py
@@ -378,7 +378,10 @@ async def test_auto_refresh_token3():
 @pytest.mark.asyncio
 async def test_auto_refresh_token4():
     async def _update_token(token, refresh_token=None, access_token=None):
-        await asyncio.sleep(0.1) # artificial sleep to force other coroutines to wake
+        # This test only makes sense if the expired token is refreshed
+        token["expires_at"] = int(time.time()) + 3600
+        # artificial sleep to force other coroutines to wake
+        await asyncio.sleep(0.1)
 
     update_token = mock.Mock(side_effect=_update_token)
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

As title. Fixes #394. The anyio package is already a transitive dependency of httpx and starlette, so the only thing preventing usage of a trio backend with the async client integrations is the `asyncio.Event` being used to guard token refreshes. `anyio.Event` does not have a `reset` method, so I took the liberty of refactoring the critical section to use a `Lock`. The result is more readable, but I did have to update one test.

I'm not comfortable enough with your test suite to add a trio backend test, so I haven't tried to make any docs changes in this PR that announce trio compatibility as a new feature in the next release. Such testing may require anyio's pytest plugins.

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
