### PR TITLE
Fragment

### DIFF
--- a/authlib/common/urls.py
+++ b/authlib/common/urls.py
@@ -94,7 +94,7 @@ def add_params_to_uri(uri, params, fragment=False):
     """Add a list of two-tuples to the uri query components."""
     sch, net, path, par, query, fra = urlparse.urlparse(uri)
     if fragment:
-        fra = add_params_to_qs(fra, params)
+        fra += '?' + add_params_to_qs('', params)
     else:
         query = add_params_to_qs(query, params)
     return urlparse.urlunparse((sch, net, path, par, query, fra))

--- a/authlib/oauth2/rfc6749/parameters.py
+++ b/authlib/oauth2/rfc6749/parameters.py
@@ -14,7 +14,7 @@ from .util import list_to_scope
 
 
 def prepare_grant_uri(uri, client_id, response_type, redirect_uri=None,
-                      scope=None, state=None, **kwargs):
+                      scope=None, state=None, in_fragment=False, **kwargs):
     """Prepare the authorization grant request URI.
 
     The client constructs the request URI by adding the following
@@ -63,7 +63,7 @@ def prepare_grant_uri(uri, client_id, response_type, redirect_uri=None,
         if kwargs[k]:
             params.append((to_unicode(k), kwargs[k]))
 
-    return add_params_to_uri(uri, params)
+    return add_params_to_uri(uri, params, fragment=in_fragment)
 
 
 def prepare_token_request(grant_type, body='', redirect_uri=None, **kwargs):


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

---

- [X] You consent that the copyright of your pull request source code belongs to Authlib's author.

This allows a parameter `in_fragment` to be passed into `prepare_grant_uri()`, when enabled, this will place OAuth parameters into the URL fragment rather than the query string. Further, it modifies `add_params_to_uri()` so that the original fragment is left unmolested (not made part of the parameters).

This is needed since I am using Vuejs for my frontend, and making API calls to perform OAuth2 authorization. I am using an authorization url such as:

http://localhost:8000/#/authorize

Without the `in_fragment` param, you would receive the url:

http://localhost:8000/?response_type=...#/authorize

And without preserving the fragment, you would get:

http://localhost:8000/#/authorize?%2Fauthorize&response_type=...

With these changes, the URL is correctly:

http://localhost:8000/#/authorize?response_type=...