### PR TITLE
Use constant time comparison for client_secret

### DIFF
--- a/authlib/integrations/sqla_oauth2/client_mixin.py
+++ b/authlib/integrations/sqla_oauth2/client_mixin.py
@@ -1,3 +1,5 @@
+import secrets
+
 from sqlalchemy import Column, String, Text, Integer
 from authlib.common.encoding import json_loads, json_dumps
 from authlib.oauth2.rfc6749 import ClientMixin
@@ -122,7 +124,7 @@ class OAuth2ClientMixin(ClientMixin):
         return bool(self.client_secret)
 
     def check_client_secret(self, client_secret):
-        return self.client_secret == client_secret
+        return secrets.compare_digest(self.client_secret, client_secret)
 
     def check_endpoint_auth_method(self, method, endpoint):
         if endpoint == 'token':

--- a/authlib/oauth2/rfc6749/models.py
+++ b/authlib/oauth2/rfc6749/models.py
@@ -73,8 +73,10 @@ class ClientMixin(object):
         """Check client_secret matching with the client. For instance, in
         the client table, the column is called ``client_secret``::
 
+            import secrets
+
             def check_client_secret(self, client_secret):
-                return self.client_secret == client_secret
+                return secrets.compare_digest(self.client_secret, client_secret)
 
         :param client_secret: A string of client secret
         :return: bool


### PR DESCRIPTION
Use `secrets.compare_digest` in the docstring of `ClientMixin.check_client_secret` and the`sqla_oauth2` `ClientMixin` implementation to prevent potential timing attacks.

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.

Ref: Issue #431 