### PR TITLE
Fix error in token response can be None

### DIFF
--- a/authlib/oauth2/client.py
+++ b/authlib/oauth2/client.py
@@ -321,7 +321,7 @@ class OAuth2Client(object):
         self.compliance_hook[hook_type].add(hook)
 
     def parse_response_token(self, token):
-        if 'error' not in token:
+        if 'error' not in token or token['error'] is None:
             self.token = token
             return self.token
 


### PR DESCRIPTION
Fix error in token response can be None for OAuth2 client, which then should be treated as success

> DO NOT SEND ANY SECURITY FIX HERE. Please read "Security Reporting" section
> on README.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
