### PR TITLE
Allow passing claims_options in StarletteOAuth2App

### DIFF
--- a/authlib/integrations/django_client/apps.py
+++ b/authlib/integrations/django_client/apps.py
@@ -75,12 +75,13 @@ class DjangoOAuth2App(DjangoAppMixin, OAuth2Mixin, OpenIDMixin, BaseApp):
                 'state': request.POST.get('state'),
             }
 
+        claims_options = kwargs.pop('claims_options', None)
         state_data = self.framework.get_state_data(request.session, params.get('state'))
         self.framework.clear_state_data(request.session, params.get('state'))
         params = self._format_state_params(state_data, params)
         token = self.fetch_access_token(**params, **kwargs)
 
         if 'id_token' in token and 'nonce' in state_data:
-            userinfo = self.parse_id_token(token, nonce=state_data['nonce'])
+            userinfo = self.parse_id_token(token, nonce=state_data['nonce'], claims_options=claims_options)
             token['userinfo'] = userinfo
         return token

--- a/authlib/integrations/flask_client/apps.py
+++ b/authlib/integrations/flask_client/apps.py
@@ -97,6 +97,7 @@ class FlaskOAuth2App(FlaskAppMixin, OAuth2Mixin, OpenIDMixin, BaseApp):
                 'state': request.form.get('state'),
             }
 
+        claims_options = kwargs.pop('claims_options', None)
         state_data = self.framework.get_state_data(session, params.get('state'))
         self.framework.clear_state_data(session, params.get('state'))
         params = self._format_state_params(state_data, params)
@@ -104,6 +105,6 @@ class FlaskOAuth2App(FlaskAppMixin, OAuth2Mixin, OpenIDMixin, BaseApp):
         self.token = token
 
         if 'id_token' in token and 'nonce' in state_data:
-            userinfo = self.parse_id_token(token, nonce=state_data['nonce'])
+            userinfo = self.parse_id_token(token, nonce=state_data['nonce'], claims_options=claims_options)
             token['userinfo'] = userinfo
         return token

--- a/authlib/integrations/starlette_client/apps.py
+++ b/authlib/integrations/starlette_client/apps.py
@@ -69,12 +69,13 @@ class StarletteOAuth2App(StarletteAppMixin, AsyncOAuth2Mixin, AsyncOpenIDMixin, 
         else:
             session = request.session
 
+        claims_options = kwargs.pop('claims_options', None)
         state_data = await self.framework.get_state_data(session, params.get('state'))
         await self.framework.clear_state_data(session, params.get('state'))
         params = self._format_state_params(state_data, params)
         token = await self.fetch_access_token(**params, **kwargs)
 
         if 'id_token' in token and 'nonce' in state_data:
-            userinfo = await self.parse_id_token(token, nonce=state_data['nonce'])
+            userinfo = await self.parse_id_token(token, nonce=state_data['nonce'], claims_options=claims_options)
             token['userinfo'] = userinfo
         return token


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.

---

This pull requests allows to put custom `claims_options` into the `StarletteOAuth2App`. This is needed for example in a multihomed Keycloak setup. Here, the users accesses Keycloak from a public URL (e.g. `https://keycloak.localhost` with a Reverse Proxy in front) which might not be reachable from the application (e.g. in a Docker Container). In that case, the program using `authlib` would access Keycloak directly using a private URL (e.g. `http://keycloak:8080`).
Here, the JWT `iss` would mismatch when retrieving the `user_info`, but the developer knows that it has two possible values: The public and the private URL. To suppress the validation error, the base function `AsyncOpenIDMixin.parse_id_token` allows setting custom `claims_options`, but in `StarletteOAuth2App`, that was impossible to do.
