### PR TITLE
Fix typo in register_token_generator docstring

### DIFF
--- a/authlib/oauth2/rfc6749/authorization_server.py
+++ b/authlib/oauth2/rfc6749/authorization_server.py
@@ -60,7 +60,7 @@ class AuthorizationServer(object):
     def register_token_generator(self, grant_type, func):
         """Register a function as token generator for the given ``grant_type``.
         Developers MUST register a default token generator with a special
-        ``grant_type=none``::
+        ``grant_type=default``::
 
             def generate_bearer_token(grant_type, client, user=None, scope=None,
                                       expires_in=None, include_refresh_token=True):
@@ -70,7 +70,7 @@ class AuthorizationServer(object):
                 ...
                 return token
 
-            authorization_server.register_token_generator('none', generate_bearer_token)
+            authorization_server.register_token_generator('default', generate_bearer_token)
 
         If you register a generator for a certain grant type, that generator will only works
         for the given grant type::


### PR DESCRIPTION
In `generate_token` method we are getting default generator with: `func = self._token_generators.get('default')`.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Other, please describe: docstring update.

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

(If no, please delete the above question and this text message.)

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
