### PR TITLE
docs: Fix a few typos

### DIFF
--- a/BACKERS.md
+++ b/BACKERS.md
@@ -13,7 +13,7 @@ Many thanks to these awesome sponsors and backers.
 </tr>
 <tr>
 <td><img align="middle" width="48" src="https://user-images.githubusercontent.com/290496/67944168-33843980-fc1f-11e9-8f69-6a7515344b92.png"></td>
-<td>For quickly implementing token-based authencation, feel free to check <a href="https://learn.authing.cn/authing/sdk/sdk-for-python">Authing's Python SDK</a>.</td>
+<td>For quickly implementing token-based authentication, feel free to check <a href="https://learn.authing.cn/authing/sdk/sdk-for-python">Authing's Python SDK</a>.</td>
 </tr>
 </table>
 

--- a/docs/client/oauth2.rst
+++ b/docs/client/oauth2.rst
@@ -135,7 +135,7 @@ the ``response_type`` of ``token``::
     >>> print(uri)
     https://some-service.com/oauth/authorize?response_type=token&client_id=be..4d&...
 
-Visit this link, and grant the authorization, the OAuth authoirzation server will
+Visit this link, and grant the authorization, the OAuth authorization server will
 redirect back to your redirect_uri, the response url would be something like::
 
     https://example.com/cb#access_token=2..WpA&state=xyz&token_type=bearer&expires_in=3600

--- a/docs/jose/jwt.rst
+++ b/docs/jose/jwt.rst
@@ -64,7 +64,7 @@ dict of the payload::
 .. important::
 
    This decoding method is insecure. By default ``jwt.decode`` parses the alg header.
-   This allows symmetric macs and asymmetric signatures. If both are allowed a signatrue bypass described in CVE-2016-10555 is possible.
+   This allows symmetric macs and asymmetric signatures. If both are allowed a signature bypass described in CVE-2016-10555 is possible.
 
    See the following section for a mitigation.
 


### PR DESCRIPTION
There are small typos in:
- BACKERS.md
- docs/client/oauth2.rst
- docs/jose/jwt.rst

Fixes:
- Should read `signature` rather than `signatrue`.
- Should read `authorization` rather than `authoirzation`.
- Should read `authentication` rather than `authencation`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md