### PR TITLE
Use InvalidGrantError for invalid code, redirect_uri, user

### DIFF
--- a/authlib/oauth2/rfc6749/grants/authorization_code.py
+++ b/authlib/oauth2/rfc6749/grants/authorization_code.py
@@ -268,7 +268,7 @@ class AuthorizationCodeGrant(BaseGrant, AuthorizationEndpointMixin, TokenEndpoin
 
         user = self.authenticate_user(authorization_code)
         if not user:
-            raise InvalidRequestError('There is no "user" for this code.')
+            raise InvalidGrantError('There is no "user" for this code.')
         self.request.user = user
 
         scope = authorization_code.get_scope()

--- a/authlib/oauth2/rfc6749/grants/authorization_code.py
+++ b/authlib/oauth2/rfc6749/grants/authorization_code.py
@@ -6,6 +6,7 @@ from ..errors import (
     OAuth2Error,
     UnauthorizedClientError,
     InvalidClientError,
+    InvalidGrantError,
     InvalidRequestError,
     AccessDeniedError,
 )
@@ -220,14 +221,14 @@ class AuthorizationCodeGrant(BaseGrant, AuthorizationEndpointMixin, TokenEndpoin
         # code was issued to "client_id" in the request
         authorization_code = self.query_authorization_code(code, client)
         if not authorization_code:
-            raise InvalidRequestError('Invalid "code" in request.')
+            raise InvalidGrantError('Invalid "code" in request.')
 
         # validate redirect_uri parameter
         log.debug('Validate token redirect_uri of %r', client)
         redirect_uri = self.request.redirect_uri
         original_redirect_uri = authorization_code.get_redirect_uri()
         if original_redirect_uri and redirect_uri != original_redirect_uri:
-            raise InvalidRequestError('Invalid "redirect_uri" in request.')
+            raise InvalidGrantError('Invalid "redirect_uri" in request.')
 
         # save for create_token_response
         self.request.client = client

--- a/tests/django/test_oauth2/test_authorization_code_grant.py
+++ b/tests/django/test_oauth2/test_authorization_code_grant.py
@@ -149,7 +149,7 @@ class AuthorizationCodeTest(TestCase):
         resp = server.create_token_response(request)
         self.assertEqual(resp.status_code, 400)
         data = json.loads(resp.content)
-        self.assertEqual(data['error'], 'invalid_request')
+        self.assertEqual(data['error'], 'invalid_grant')
 
     def test_create_token_response_success(self):
         self.prepare_data()

--- a/tests/flask/test_oauth2/test_authorization_code_grant.py
+++ b/tests/flask/test_oauth2/test_authorization_code_grant.py
@@ -135,14 +135,14 @@ class AuthorizationCodeTest(TestCase):
             'code': 'no-user',
         }, headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(resp['error'], 'invalid_request')
+        self.assertEqual(resp['error'], 'invalid_grant')
 
     def test_invalid_redirect_uri(self):
         self.prepare_data()
         uri = self.authorize_url + '&redirect_uri=https%3A%2F%2Fa.c'
         rv = self.client.post(uri, data={'user_id': '1'})
         resp = json.loads(rv.data)
-        self.assertEqual(resp['error'], 'invalid_request')
+        self.assertEqual(resp['error'], 'invalid_grant')
 
         uri = self.authorize_url + '&redirect_uri=https%3A%2F%2Fa.b'
         rv = self.client.post(uri, data={'user_id': '1'})

--- a/tests/flask/test_oauth2/test_authorization_code_grant.py
+++ b/tests/flask/test_oauth2/test_authorization_code_grant.py
@@ -156,7 +156,7 @@ class AuthorizationCodeTest(TestCase):
             'code': code,
         }, headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(resp['error'], 'invalid_request')
+        self.assertEqual(resp['error'], 'invalid_grant')
 
     def test_invalid_grant_type(self):
         self.prepare_data(

--- a/tests/flask/test_oauth2/test_authorization_code_grant.py
+++ b/tests/flask/test_oauth2/test_authorization_code_grant.py
@@ -121,7 +121,7 @@ class AuthorizationCodeTest(TestCase):
             'code': 'invalid',
         }, headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(resp['error'], 'invalid_request')
+        self.assertEqual(resp['error'], 'invalid_grant')
 
         code = AuthorizationCode(
             code='no-user',
@@ -142,7 +142,7 @@ class AuthorizationCodeTest(TestCase):
         uri = self.authorize_url + '&redirect_uri=https%3A%2F%2Fa.c'
         rv = self.client.post(uri, data={'user_id': '1'})
         resp = json.loads(rv.data)
-        self.assertEqual(resp['error'], 'invalid_grant')
+        self.assertEqual(resp['error'], 'invalid_request')
 
         uri = self.authorize_url + '&redirect_uri=https%3A%2F%2Fa.b'
         rv = self.client.post(uri, data={'user_id': '1'})


### PR DESCRIPTION
Currently, when validating params of `POST /token`, if the `code` or `redirect_uri` is invalid authlib returns an "invalid_request" error type.

[RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html#section-5.2) specifies that the `error` value will be `invalid_grant` in these cases:
>         invalid_grant
>               The provided authorization grant (e.g., authorization
>               code, resource owner credentials) or refresh token is
>               invalid, expired, revoked, does not match the redirection
>               URI used in the authorization request, or was issued to
>               another client.

---

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

Clients which depend on the current behavior of `error` could potentially be impacted by this change.

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
