### PR TITLE
Remove confusing `-U` from a snippet

### DIFF
--- a/docs/client/index.rst
+++ b/docs/client/index.rst
@@ -22,7 +22,7 @@ example, you want to use ``requests`` OAuth clients::
 
 For instance, you want to use ``httpx`` OAuth clients::
 
-    $ pip install -U Authlib httpx
+    $ pip install Authlib httpx
 
 Here is a simple overview of Flask OAuth client::
 


### PR DESCRIPTION
The `-U` in `pip install -U Authlib httpx` is confusing -- it doesn't add anything to the snippet and just raises a question of "why `-U`" which is answered, after a trip to Pip documentation, by "it isn't needed there, in general".

> DO NOT SEND ANY SECURITY FIX HERE. Please read "Security Reporting" section
> on README.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

(If no, please delete the above question and this text message.)

---

- [ ] You consent that the copyright of your pull request source code belongs to Authlib's author.
