### PR TITLE
docs: CodeChallenge(required=True) only applies to public clients

### DIFF
--- a/docs/specs/rfc7636.rst
+++ b/docs/specs/rfc7636.rst
@@ -63,7 +63,7 @@ Now you can register your ``AuthorizationCodeGrant`` with the extension::
     from authlib.oauth2.rfc7636 import CodeChallenge
     server.register_grant(MyAuthorizationCodeGrant, [CodeChallenge(required=True)])
 
-If ``required=True``, code challenge is required for authorization code flow.
+If ``required=True``, code challenge is required for authorization code flow from public clients.
 If ``required=False``, it is optional, it will only valid the code challenge
 when clients send these parameters.
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Other, please describe: documentation change

---

I've had to look through code to make sure, but it seems the CodeChallenge is only required when the client uses "none" authentication - which I understand as being a public client. This makes it explicit in the documentation.

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
