### PR TITLE
TokenMixin: actually raise a NotImplementedError

### DIFF
--- a/authlib/oauth2/rfc6749/models.py
+++ b/authlib/oauth2/rfc6749/models.py
@@ -225,4 +225,4 @@ class TokenMixin(object):
 
         :return: boolean
         """
-        return NotImplementedError()
+        raise NotImplementedError()


### PR DESCRIPTION
The previous version made tokens always look revoked. This change makes sure programmers (and IDEs) are properly notified about missing is_revoked implementation..

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
