### PR TITLE
Fixed RFC7592 Dynamic Client Registration Management Protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Generic, spec-compliant implementation to build clients and providers:
   - [RFC7009: OAuth 2.0 Token Revocation](https://docs.authlib.org/en/latest/specs/rfc7009.html)
   - [RFC7523: JWT Profile for OAuth 2.0 Client Authentication and Authorization Grants](https://docs.authlib.org/en/latest/specs/rfc7523.html)
   - [RFC7591: OAuth 2.0 Dynamic Client Registration Protocol](https://docs.authlib.org/en/latest/specs/rfc7591.html)
-  - [ ] RFC7592: OAuth 2.0 Dynamic Client Registration Management Protocol
+  - [RFC7592: OAuth 2.0 Dynamic Client Registration Management Protocol](https://docs.authlib.org/en/latest/specs/rfc7592.html)
   - [RFC7636: Proof Key for Code Exchange by OAuth Public Clients](https://docs.authlib.org/en/latest/specs/rfc7636.html)
   - [RFC7662: OAuth 2.0 Token Introspection](https://docs.authlib.org/en/latest/specs/rfc7662.html)
   - [RFC8414: OAuth 2.0 Authorization Server Metadata](https://docs.authlib.org/en/latest/specs/rfc8414.html)

--- a/authlib/integrations/flask_helpers.py
+++ b/authlib/integrations/flask_helpers.py
@@ -9,7 +9,7 @@ def create_oauth_request(request, request_cls, use_json=False):
     if not request:
         request = flask_req
 
-    if request.method == 'POST':
+    if request.method in ('POST', 'PUT'):
         if use_json:
             body = request.get_json()
         else:

--- a/authlib/integrations/sqla_oauth2/client_mixin.py
+++ b/authlib/integrations/sqla_oauth2/client_mixin.py
@@ -39,6 +39,8 @@ class OAuth2ClientMixin(ClientMixin):
 
     def set_client_metadata(self, value):
         self._client_metadata = json_dumps(value)
+        if 'client_metadata' in self.__dict__:
+            del self.__dict__['client_metadata']
 
     @property
     def redirect_uris(self):

--- a/authlib/oauth2/rfc7592/endpoint.py
+++ b/authlib/oauth2/rfc7592/endpoint.py
@@ -250,3 +250,9 @@ class ClientConfigurationEndpoint(object):
         """
 
         raise NotImplementedError()
+
+    def get_server_metadata(self):
+        """Return server metadata which includes supported grant types,
+        response types and etc.
+        """
+        raise NotImplementedError()

--- a/authlib/oauth2/rfc7592/endpoint.py
+++ b/authlib/oauth2/rfc7592/endpoint.py
@@ -12,7 +12,7 @@ from ..rfc7591 import UnapprovedSoftwareStatementError
 
 
 class ClientConfigurationEndpoint(object):
-    ENDPOINT_NAME = "client_configuration"
+    ENDPOINT_NAME = 'client_configuration'
 
     #: The claims validation class
     claims_class = ClientMetadataClaims
@@ -47,11 +47,11 @@ class ClientConfigurationEndpoint(object):
 
         request.client = client
 
-        if request.method == "GET":
+        if request.method == 'GET':
             return self.create_read_client_response(client, request)
-        elif request.method == "DELETE":
+        elif request.method == 'DELETE':
             return self.create_delete_client_response(client, request)
-        elif request.method == "PUT":
+        elif request.method == 'PUT':
             return self.create_update_client_response(client, request)
 
     def create_endpoint_request(self, request):
@@ -65,37 +65,37 @@ class ClientConfigurationEndpoint(object):
     def create_delete_client_response(self, client, request):
         self.delete_client(client, request)
         headers = [
-            ("Cache-Control", "no-store"),
-            ("Pragma", "no-cache"),
+            ('Cache-Control', 'no-store'),
+            ('Pragma', 'no-cache'),
         ]
-        return 204, "", headers
+        return 204, '', headers
 
     def create_update_client_response(self, client, request):
         # The updated client metadata fields request MUST NOT include the
-        # "registration_access_token", "registration_client_uri",
-        # "client_secret_expires_at", or "client_id_issued_at" fields
+        # 'registration_access_token', 'registration_client_uri',
+        # 'client_secret_expires_at', or 'client_id_issued_at' fields
         must_not_include = (
-            "registration_access_token",
-            "registration_client_uri",
-            "client_secret_expires_at",
-            "client_id_issued_at",
+            'registration_access_token',
+            'registration_client_uri',
+            'client_secret_expires_at',
+            'client_id_issued_at',
         )
         for k in must_not_include:
             if k in request.data:
                 raise InvalidRequestError()
 
-        # The client MUST include its "client_id" field in the request
-        client_id = request.data.get("client_id")
+        # The client MUST include its 'client_id' field in the request
+        client_id = request.data.get('client_id')
         if not client_id:
             raise InvalidRequestError()
         if client_id != client.get_client_id():
             raise InvalidRequestError()
 
-        # If the client includes the "client_secret" field in the request,
+        # If the client includes the 'client_secret' field in the request,
         # the value of this field MUST match the currently issued client
         # secret for that client.
-        if "client_secret" in request.data:
-            if not client.check_client_secret(request.data["client_secret"]):
+        if 'client_secret' in request.data:
+            if not client.check_client_secret(request.data['client_secret']):
                 raise InvalidRequestError()
 
         client_metadata = self.extract_client_metadata(request)
@@ -118,10 +118,10 @@ class ClientConfigurationEndpoint(object):
         if not metadata:
             return {}
 
-        scopes_supported = metadata.get("scopes_supported")
-        response_types_supported = metadata.get("response_types_supported")
-        grant_types_supported = metadata.get("grant_types_supported")
-        auth_methods_supported = metadata.get("token_endpoint_auth_methods_supported")
+        scopes_supported = metadata.get('scopes_supported')
+        response_types_supported = metadata.get('response_types_supported')
+        grant_types_supported = metadata.get('grant_types_supported')
+        auth_methods_supported = metadata.get('token_endpoint_auth_methods_supported')
         options = {}
         if scopes_supported is not None:
             scopes_supported = set(scopes_supported)
@@ -132,7 +132,7 @@ class ClientConfigurationEndpoint(object):
                 scopes = set(scope_to_list(value))
                 return scopes_supported.issuperset(scopes)
 
-            options["scope"] = {"validate": _validate_scope}
+            options['scope'] = {'validate': _validate_scope}
 
         if response_types_supported is not None:
             response_types_supported = set(response_types_supported)
@@ -140,7 +140,7 @@ class ClientConfigurationEndpoint(object):
             def _validate_response_types(claims, value):
                 return response_types_supported.issuperset(set(value))
 
-            options["response_types"] = {"validate": _validate_response_types}
+            options['response_types'] = {'validate': _validate_response_types}
 
         if grant_types_supported is not None:
             grant_types_supported = set(grant_types_supported)
@@ -148,10 +148,10 @@ class ClientConfigurationEndpoint(object):
             def _validate_grant_types(claims, value):
                 return grant_types_supported.issuperset(set(value))
 
-            options["grant_types"] = {"validate": _validate_grant_types}
+            options['grant_types'] = {'validate': _validate_grant_types}
 
         if auth_methods_supported is not None:
-            options["token_endpoint_auth_method"] = {"values": auth_methods_supported}
+            options['token_endpoint_auth_method'] = {'values': auth_methods_supported}
 
         return options
 
@@ -165,7 +165,7 @@ class ClientConfigurationEndpoint(object):
         information.::
 
             def generate_client_registration_info(self, client, request):{
-                access_token = request.headers["Authorization"].split(" ")[1]
+                access_token = request.headers['Authorization'].split(' ')[1]
                 return {
                     'registration_client_uri': request.uri,
                     'registration_access_token': access_token,

--- a/authlib/oauth2/rfc7592/endpoint.py
+++ b/authlib/oauth2/rfc7592/endpoint.py
@@ -1,10 +1,21 @@
 from authlib.consts import default_json_headers
+from authlib.jose import JsonWebToken, JoseError
+from ..rfc7591.claims import ClientMetadataClaims
+from ..rfc6749 import scope_to_list
 from ..rfc6749 import AccessDeniedError
-from ..rfc6750 import InvalidTokenError
+from ..rfc6749 import InvalidClientError
+from ..rfc6749 import InvalidRequestError
+from ..rfc6749 import UnauthorizedClientError
+from ..rfc7591 import InvalidClientMetadataError
+from ..rfc7591 import InvalidSoftwareStatementError
+from ..rfc7591 import UnapprovedSoftwareStatementError
 
 
 class ClientConfigurationEndpoint(object):
-    ENDPOINT_NAME = 'client_configuration'
+    ENDPOINT_NAME = "client_configuration"
+
+    #: The claims validation class
+    claims_class = ClientMetadataClaims
 
     def __init__(self, server):
         self.server = server
@@ -13,9 +24,11 @@ class ClientConfigurationEndpoint(object):
         return self.create_configuration_response(request)
 
     def create_configuration_response(self, request):
+        # This request is authenticated by the registration access token issued
+        # to the client.
         token = self.authenticate_token(request)
         if not token:
-            raise InvalidTokenError()
+            raise AccessDeniedError()
 
         request.credential = token
 
@@ -25,20 +38,20 @@ class ClientConfigurationEndpoint(object):
             # with HTTP 401 Unauthorized and the registration access token used to
             # make this request SHOULD be immediately revoked.
             self.revoke_access_token(request)
-            raise InvalidTokenError()
+            raise InvalidClientError(status_code=401)
 
         if not self.check_permission(client, request):
             # If the client does not have permission to read its record, the server
             # MUST return an HTTP 403 Forbidden.
-            raise AccessDeniedError()
+            raise UnauthorizedClientError(status_code=403)
 
         request.client = client
 
-        if request.method == 'GET':
+        if request.method == "GET":
             return self.create_read_client_response(client, request)
-        elif request.method == 'DELETE':
+        elif request.method == "DELETE":
             return self.create_delete_client_response(client, request)
-        elif request.method == 'PUT':
+        elif request.method == "PUT":
             return self.create_update_client_response(client, request)
 
     def create_endpoint_request(self, request):
@@ -46,90 +59,121 @@ class ClientConfigurationEndpoint(object):
 
     def create_read_client_response(self, client, request):
         body = self.introspect_client(client)
-        info = self.generate_client_registration_info(client, request)
-        body.update(info)
+        body.update(self.generate_client_registration_info(client, request))
         return 200, body, default_json_headers
 
     def create_delete_client_response(self, client, request):
-        """To deprive itself on the authorization server, the client makes
-        an HTTP DELETE request to the client configuration endpoint.  This
-        request is authenticated by the registration access token issued to
-        the client.
-
-        The following is a non-normative example request::
-
-            DELETE /register/s6BhdRkqt3 HTTP/1.1
-            Host: server.example.com
-            Authorization: Bearer reg-23410913-abewfq.123483
-        """
         self.delete_client(client, request)
         headers = [
-            ('Cache-Control', 'no-store'),
-            ('Pragma', 'no-cache'),
+            ("Cache-Control", "no-store"),
+            ("Pragma", "no-cache"),
         ]
-        return 204, '', headers
+        return 204, "", headers
 
     def create_update_client_response(self, client, request):
-        """ To update a previously registered client's registration with an
-        authorization server, the client makes an HTTP PUT request to the
-        client configuration endpoint with a content type of "application/
-        json".
-
-        The following is a non-normative example request::
-
-            PUT /register/s6BhdRkqt3 HTTP/1.1
-            Accept: application/json
-            Host: server.example.com
-            Authorization: Bearer reg-23410913-abewfq.123483
-
-            {
-                "client_id": "s6BhdRkqt3",
-                "client_secret": "cf136dc3c1fc93f31185e5885805d",
-                "redirect_uris": [
-                    "https://client.example.org/callback",
-                    "https://client.example.org/alt"
-                ],
-                "grant_types": ["authorization_code", "refresh_token"],
-                "token_endpoint_auth_method": "client_secret_basic",
-                "jwks_uri": "https://client.example.org/my_public_keys.jwks",
-                "client_name": "My New Example",
-                "client_name#fr": "Mon Nouvel Exemple",
-                "logo_uri": "https://client.example.org/newlogo.png",
-                "logo_uri#fr": "https://client.example.org/fr/newlogo.png"
-            }
-        """
         # The updated client metadata fields request MUST NOT include the
         # "registration_access_token", "registration_client_uri",
         # "client_secret_expires_at", or "client_id_issued_at" fields
         must_not_include = (
-            'registration_access_token', 'registration_client_uri',
-            'client_secret_expires_at', 'client_id_issued_at',
+            "registration_access_token",
+            "registration_client_uri",
+            "client_secret_expires_at",
+            "client_id_issued_at",
         )
         for k in must_not_include:
             if k in request.data:
-                return
+                raise InvalidRequestError()
 
         # The client MUST include its "client_id" field in the request
-        client_id = request.data.get('client_id')
+        client_id = request.data.get("client_id")
         if not client_id:
-            raise
+            raise InvalidRequestError()
         if client_id != client.get_client_id():
-            raise
+            raise InvalidRequestError()
 
         # If the client includes the "client_secret" field in the request,
         # the value of this field MUST match the currently issued client
         # secret for that client.
-        if 'client_secret' in request.data:
-            if not client.check_client_secret(request.data['client_secret']):
-                raise
+        if "client_secret" in request.data:
+            if not client.check_client_secret(request.data["client_secret"]):
+                raise InvalidRequestError()
 
-        client = self.save_client(client, request)
+        client_metadata = self.extract_client_metadata(request)
+        client = self.update_client(client, client_metadata, request)
         return self.create_read_client_response(client, request)
+
+    def extract_client_metadata(self, request):
+        json_data = request.data.copy()
+        options = self.get_claims_options()
+        claims = self.claims_class(json_data, {}, options, self.get_server_metadata())
+
+        try:
+            claims.validate()
+        except JoseError as error:
+            raise InvalidClientMetadataError(error.description)
+        return claims.get_registered_claims()
+
+    def get_claims_options(self):
+        metadata = self.get_server_metadata()
+        if not metadata:
+            return {}
+
+        scopes_supported = metadata.get("scopes_supported")
+        response_types_supported = metadata.get("response_types_supported")
+        grant_types_supported = metadata.get("grant_types_supported")
+        auth_methods_supported = metadata.get("token_endpoint_auth_methods_supported")
+        options = {}
+        if scopes_supported is not None:
+            scopes_supported = set(scopes_supported)
+
+            def _validate_scope(claims, value):
+                if not value:
+                    return True
+                scopes = set(scope_to_list(value))
+                return scopes_supported.issuperset(scopes)
+
+            options["scope"] = {"validate": _validate_scope}
+
+        if response_types_supported is not None:
+            response_types_supported = set(response_types_supported)
+
+            def _validate_response_types(claims, value):
+                return response_types_supported.issuperset(set(value))
+
+            options["response_types"] = {"validate": _validate_response_types}
+
+        if grant_types_supported is not None:
+            grant_types_supported = set(grant_types_supported)
+
+            def _validate_grant_types(claims, value):
+                return grant_types_supported.issuperset(set(value))
+
+            options["grant_types"] = {"validate": _validate_grant_types}
+
+        if auth_methods_supported is not None:
+            options["token_endpoint_auth_method"] = {"values": auth_methods_supported}
+
+        return options
+
+    def introspect_client(self, client):
+        return {**client.client_info, **client.client_metadata}
 
     def generate_client_registration_info(self, client, request):
         """Generate ```registration_client_uri`` and ``registration_access_token``
-        for RFC7592. This method returns ``None`` by default. Developers MAY rewrite
-        this method to return registration information."""
+        for RFC7592. By default this method returns the values sent in the current
+        request. Developers MUST rewrite this method to return different registration
+        information.::
+
+            def generate_client_registration_info(self, client, request):{
+                access_token = request.headers["Authorization"].split(" ")[1]
+                return {
+                    'registration_client_uri': request.uri,
+                    'registration_access_token': access_token,
+                }
+
+        :param client: the instance of OAuth client
+        :param request: formatted request instance
+        """
         raise NotImplementedError()
 
     def authenticate_token(self, request):
@@ -145,15 +189,37 @@ class ClientConfigurationEndpoint(object):
         raise NotImplementedError()
 
     def authenticate_client(self, request):
+        """Read a client from the request payload.
+        Developers MUST implement this method in subclass::
+
+            def authenticate_client(self, request):
+                return Client.query.get(request.data.get('client_id'))
+
+        :return: client instance
+        """
         raise NotImplementedError()
 
     def revoke_access_token(self, request):
+        """Revoke a token access in case an invalid client has been requested.
+        Developers MUST implement this method in subclass::
+
+            def revoke_access_token(self, request):
+                request.credential.revoked = True
+                db.session.add(request.token)
+                db.session.commit()
+
+        """
         raise NotImplementedError()
 
     def check_permission(self, client, request):
-        raise NotImplementedError()
+        """Checks wether the current client is allowed to be accessed, edited
+        or deleted. Developers MUST implement it in subclass, e.g.::
 
-    def introspect_client(self, client):
+            def check_permission(self, client, request):
+                return client.editable
+
+        :return: boolean
+        """
         raise NotImplementedError()
 
     def delete_client(self, client, request):
@@ -161,12 +227,28 @@ class ClientConfigurationEndpoint(object):
         implement it in subclass, e.g.::
 
             def delete_client(self, client, request):
-                client.delete()
+                db.session.delete(client)
+                db.session.commit()
 
         :param client: the instance of OAuth client
         :param request: formatted request instance
         """
         raise NotImplementedError()
 
-    def save_client(self, client, request):
+    def update_client(self, client, client_metadata, request):
+        """Update the client in the database. Developers MUST implement this method
+        in subclass::
+
+            def update_client(self, client, client_metadata, request):
+                client.set_client_metadata({**client.client_metadata, **client_metadata})
+                db.session.add(client)
+                db.session.commit()
+                return client
+
+        :param client: the instance of OAuth client
+        :param client_metadata: a dict of the client claims to update
+        :param request: formatted request instance
+        :return: client instance
+        """
+
         raise NotImplementedError()

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Version 1.2.0
 - Use ``flask.g`` instead of ``_app_ctx_stack``, via :gh:`issue#482`.
 - Add ``headers`` parameter back to ``ClientSecretJWT``, via :gh:`issue#457`.
 - Always passing ``realm`` parameter in OAuth 1 clients, via :gh:`issue#339`.
+- Implemented RFC7592 Dynamic Client Registration Management Protocol, via :gh:`issue#499`.
 
 
 Version 1.1.0

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,7 +15,7 @@ Version 1.2.0
 - Use ``flask.g`` instead of ``_app_ctx_stack``, via :gh:`issue#482`.
 - Add ``headers`` parameter back to ``ClientSecretJWT``, via :gh:`issue#457`.
 - Always passing ``realm`` parameter in OAuth 1 clients, via :gh:`issue#339`.
-- Implemented RFC7592 Dynamic Client Registration Management Protocol, via :gh:`PR#499`.
+- Implemented RFC7592 Dynamic Client Registration Management Protocol, via :gh:`PR#505`.
 
 
 Version 1.1.0

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,7 +15,7 @@ Version 1.2.0
 - Use ``flask.g`` instead of ``_app_ctx_stack``, via :gh:`issue#482`.
 - Add ``headers`` parameter back to ``ClientSecretJWT``, via :gh:`issue#457`.
 - Always passing ``realm`` parameter in OAuth 1 clients, via :gh:`issue#339`.
-- Implemented RFC7592 Dynamic Client Registration Management Protocol, via :gh:`issue#499`.
+- Implemented RFC7592 Dynamic Client Registration Management Protocol, via :gh:`PR#499`.
 
 
 Version 1.1.0

--- a/docs/specs/index.rst
+++ b/docs/specs/index.rst
@@ -19,6 +19,7 @@ works.
     rfc7519
     rfc7523
     rfc7591
+    rfc7592
     rfc7636
     rfc7638
     rfc7662

--- a/docs/specs/rfc7592.rst
+++ b/docs/specs/rfc7592.rst
@@ -65,6 +65,32 @@ Before register the endpoint, developers MUST implement the missing methods::
                 'registration_access_token': access_token,
             }
 
+        def get_server_metadata(self):
+            return {
+                'issuer': ...,
+                'authorization_endpoint': ...,
+                'token_endpoint': ...,
+                'jwks_uri': ...,
+                'registration_endpoint': ...,
+                'scopes_supported': ...,
+                'response_types_supported': ...,
+                'response_modes_supported': ...,
+                'grant_types_supported': ...,
+                'token_endpoint_auth_methods_supported': ...,
+                'token_endpoint_auth_signing_alg_values_supported': ...,
+                'service_documentation': ...,
+                'ui_locales_supported': ...,
+                'op_policy_uri': ...,
+                'op_tos_uri': ...,
+                'revocation_endpoint': ...,
+                'revocation_endpoint_auth_methods_supported': ...,
+                'revocation_endpoint_auth_signing_alg_values_supported': ...,
+                'introspection_endpoint': ...,
+                'introspection_endpoint_auth_methods_supported': ...,
+                'introspection_endpoint_auth_signing_alg_values_supported': ...,
+                'code_challenge_methods_supported': ...,
+            }
+
 API Reference
 -------------
 

--- a/docs/specs/rfc7592.rst
+++ b/docs/specs/rfc7592.rst
@@ -30,25 +30,23 @@ Before register the endpoint, developers MUST implement the missing methods::
             # this method is used to authenticate the registration access
             # token returned by the RFC7591 registration endpoint
             auth_header = request.headers.get('Authorization')
-            # bearer a-token-string
             bearer_token = auth_header.split()[1]
-            token = Token.query.get(bearer_token)
+            token = Token.get(bearer_token)
             return token
 
         def authenticate_client(self, request):
-            return Client.query.filter_by(
-                client_id=request.data.get('client_id')
-            ).first()
+            client_id = request.data.get('client_id')
+            return Client.get(client_id=client_id)
 
-        def revoke_access_token(self, request):
-            request.credential.revoked = True
+        def revoke_access_token(self, token, request):
+            token.revoked = True
+            token.save()
 
         def check_permission(self, client, request):
             return client.editable
 
         def delete_client(self, client, request):
-            db.session.delete(client)
-            db.session.commit()
+            client.delete()
 
         def save_client(self, client_info, client_metadata, request):
             client = OAuthClient(

--- a/docs/specs/rfc7592.rst
+++ b/docs/specs/rfc7592.rst
@@ -1,0 +1,75 @@
+.. _specs/rfc7592:
+
+RFC7592: OAuth 2.0 Dynamic Client Registration Management Protocol
+==================================================================
+
+This section contains the generic implementation of RFC7592_. OAuth 2.0 Dynamic
+Client Registration Management Protocol allows developers edit and delete OAuth
+client via API through Authorization Server. This specification is an extension
+of :ref:`specs/rfc7591`.
+
+
+.. meta::
+    :description: Python API references on RFC7592 OAuth 2.0 Dynamic Client
+        Registration Management Protocol in Python with Authlib implementation.
+
+.. module:: authlib.oauth2.rfc7592
+
+.. _RFC7592: https://tools.ietf.org/html/rfc7592
+
+Client Configuration Endpoint
+-----------------------------
+
+Before register the endpoint, developers MUST implement the missing methods::
+
+    from authlib.oauth2.rfc7592 import ClientConfigurationEndpoint
+
+
+    class MyClientConfigurationEndpoint(ClientConfigurationEndpoint):
+        def authenticate_token(self, request):
+            # this method is used to authenticate the registration access
+            # token returned by the RFC7591 registration endpoint
+            auth_header = request.headers.get('Authorization')
+            # bearer a-token-string
+            bearer_token = auth_header.split()[1]
+            token = Token.query.get(bearer_token)
+            return token
+
+        def authenticate_client(self, request):
+            return Client.query.filter_by(
+                client_id=request.data.get('client_id')
+            ).first()
+
+        def revoke_access_token(self, request):
+            request.credential.revoked = True
+
+        def check_permission(self, client, request):
+            return client.editable
+
+        def delete_client(self, client, request):
+            db.session.delete(client)
+            db.session.commit()
+
+        def save_client(self, client_info, client_metadata, request):
+            client = OAuthClient(
+                user_id=request.credential.user_id,
+                client_id=client_info['client_id'],
+                client_secret=client_info['client_secret'],
+                **client_metadata,
+            )
+            client.save()
+            return client
+
+        def generate_client_registration_info(self, client, request):
+            access_token = request.headers["Authorization"].split(" ")[1]
+            return {
+                "registration_client_uri": request.uri,
+                "registration_access_token": access_token,
+            }
+
+API Reference
+-------------
+
+.. autoclass:: ClientConfigurationEndpoint
+    :member-order: bysource
+    :members:

--- a/docs/specs/rfc7592.rst
+++ b/docs/specs/rfc7592.rst
@@ -61,10 +61,10 @@ Before register the endpoint, developers MUST implement the missing methods::
             return client
 
         def generate_client_registration_info(self, client, request):
-            access_token = request.headers["Authorization"].split(" ")[1]
+            access_token = request.headers['Authorization'].split(' ')[1]
             return {
-                "registration_client_uri": request.uri,
-                "registration_access_token": access_token,
+                'registration_client_uri': request.uri,
+                'registration_access_token': access_token,
             }
 
 API Reference

--- a/tests/flask/test_oauth2/test_client_configuration_endpoint.py
+++ b/tests/flask/test_oauth2/test_client_configuration_endpoint.py
@@ -32,6 +32,8 @@ class ClientConfigurationEndpoint(_ClientConfigurationEndpoint):
 
     def revoke_access_token(self, request, token):
         token.revoked = True
+        db.session.add(token)
+        db.session.commit()
 
     def check_permission(self, client, request):
         client_id = request.uri.split('/')[-1]

--- a/tests/flask/test_oauth2/test_client_configuration_endpoint.py
+++ b/tests/flask/test_oauth2/test_client_configuration_endpoint.py
@@ -30,8 +30,8 @@ class ClientConfigurationEndpoint(_ClientConfigurationEndpoint):
         client_id = request.uri.split('/')[-1]
         return Client.query.filter_by(client_id=client_id).first()
 
-    def revoke_access_token(self, request):
-        request.credential.revoked = True
+    def revoke_access_token(self, request, token):
+        token.revoked = True
 
     def check_permission(self, client, request):
         client_id = request.uri.split('/')[-1]

--- a/tests/flask/test_oauth2/test_client_configuration_endpoint.py
+++ b/tests/flask/test_oauth2/test_client_configuration_endpoint.py
@@ -102,31 +102,31 @@ class ClientConfigurationTestMixin(TestCase):
 class ClientConfigurationReadTest(ClientConfigurationTestMixin):
     def test_read_client(self):
         user, client, token = self.prepare_data()
-        assert client.client_name == 'Authlib'
+        self.assertEqual(client.client_name, 'Authlib')
         headers = {'Authorization': f'bearer {token.access_token}'}
         rv = self.client.get('/configure_client/client_id', headers=headers)
         resp = json.loads(rv.data)
-        assert rv.status_code == 200
-        assert resp['client_id'] == client.client_id
-        assert resp['client_name'] == 'Authlib'
-        assert (
-            resp['registration_client_uri']
-            == 'http://localhost/configure_client/client_id'
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(resp['client_id'], client.client_id)
+        self.assertEqual(resp['client_name'], 'Authlib')
+        self.assertEqual(
+            resp['registration_client_uri'],
+            'http://localhost/configure_client/client_id',
         )
-        assert resp['registration_access_token'] == token.access_token
+        self.assertEqual(resp['registration_access_token'], token.access_token)
 
     def test_access_denied(self):
         user, client, token = self.prepare_data()
         rv = self.client.get('/configure_client/client_id')
         resp = json.loads(rv.data)
-        assert rv.status_code == 400
-        assert resp['error'] == 'access_denied'
+        self.assertEqual(rv.status_code, 400)
+        self.assertEqual(resp['error'], 'access_denied')
 
         headers = {'Authorization': f'bearer invalid_token'}
         rv = self.client.get('/configure_client/client_id', headers=headers)
         resp = json.loads(rv.data)
-        assert rv.status_code == 400
-        assert resp['error'] == 'access_denied'
+        self.assertEqual(rv.status_code, 400)
+        self.assertEqual(resp['error'], 'access_denied')
 
         headers = {'Authorization': f'bearer unauthorized_token'}
         rv = self.client.get(
@@ -135,8 +135,8 @@ class ClientConfigurationReadTest(ClientConfigurationTestMixin):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        assert rv.status_code == 400
-        assert resp['error'] == 'access_denied'
+        self.assertEqual(rv.status_code, 400)
+        self.assertEqual(resp['error'], 'access_denied')
 
     def test_invalid_client(self):
         # If the client does not exist on this server, the server MUST respond
@@ -147,8 +147,8 @@ class ClientConfigurationReadTest(ClientConfigurationTestMixin):
         headers = {'Authorization': f'bearer {token.access_token}'}
         rv = self.client.get('/configure_client/invalid_client_id', headers=headers)
         resp = json.loads(rv.data)
-        assert rv.status_code == 401
-        assert resp['error'] == 'invalid_client'
+        self.assertEqual(rv.status_code, 401)
+        self.assertEqual(resp['error'], 'invalid_client')
 
     def test_unauthorized_client(self):
         # If the client does not have permission to read its record, the server
@@ -167,8 +167,8 @@ class ClientConfigurationReadTest(ClientConfigurationTestMixin):
             '/configure_client/unauthorized_client_id', headers=headers
         )
         resp = json.loads(rv.data)
-        assert rv.status_code == 403
-        assert resp['error'] == 'unauthorized_client'
+        self.assertEqual(rv.status_code, 403)
+        self.assertEqual(resp['error'], 'unauthorized_client')
 
 
 class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
@@ -181,7 +181,7 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
         # value in the request just as any other value.
 
         user, client, token = self.prepare_data()
-        assert client.client_name == 'Authlib'
+        self.assertEqual(client.client_name, 'Authlib')
         headers = {'Authorization': f'bearer {token.access_token}'}
         body = {
             'client_id': client.client_id,
@@ -189,24 +189,24 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
         }
         rv = self.client.put('/configure_client/client_id', json=body, headers=headers)
         resp = json.loads(rv.data)
-        assert rv.status_code == 200
-        assert resp['client_id'] == client.client_id
-        assert resp['client_name'] == 'NewAuthlib'
-        assert client.client_name == 'NewAuthlib'
-        assert client.scope == 'openid profile'
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(resp['client_id'], client.client_id)
+        self.assertEqual(resp['client_name'], 'NewAuthlib')
+        self.assertEqual(client.client_name, 'NewAuthlib')
+        self.assertEqual(client.scope, 'openid profile')
 
     def test_access_denied(self):
         user, client, token = self.prepare_data()
         rv = self.client.put('/configure_client/client_id', json={})
         resp = json.loads(rv.data)
-        assert rv.status_code == 400
-        assert resp['error'] == 'access_denied'
+        self.assertEqual(rv.status_code, 400)
+        self.assertEqual(resp['error'], 'access_denied')
 
         headers = {'Authorization': f'bearer invalid_token'}
         rv = self.client.put('/configure_client/client_id', json={}, headers=headers)
         resp = json.loads(rv.data)
-        assert rv.status_code == 400
-        assert resp['error'] == 'access_denied'
+        self.assertEqual(rv.status_code, 400)
+        self.assertEqual(resp['error'], 'access_denied')
 
         headers = {'Authorization': f'bearer unauthorized_token'}
         rv = self.client.put(
@@ -215,8 +215,8 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        assert rv.status_code == 400
-        assert resp['error'] == 'access_denied'
+        self.assertEqual(rv.status_code, 400)
+        self.assertEqual(resp['error'], 'access_denied')
 
     def test_invalid_request(self):
         user, client, token = self.prepare_data()
@@ -225,8 +225,8 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
         # The client MUST include its 'client_id' field in the request...
         rv = self.client.put('/configure_client/client_id', json={}, headers=headers)
         resp = json.loads(rv.data)
-        assert rv.status_code == 400
-        assert resp['error'] == 'invalid_request'
+        self.assertEqual(rv.status_code, 400)
+        self.assertEqual(resp['error'], 'invalid_request')
 
         # ... and it MUST be the same as its currently issued client identifier.
         rv = self.client.put(
@@ -235,8 +235,8 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        assert rv.status_code == 400
-        assert resp['error'] == 'invalid_request'
+        self.assertEqual(rv.status_code, 400)
+        self.assertEqual(resp['error'], 'invalid_request')
 
         # The updated client metadata fields request MUST NOT include the
         # 'registration_access_token', 'registration_client_uri',
@@ -250,8 +250,8 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        assert rv.status_code == 400
-        assert resp['error'] == 'invalid_request'
+        self.assertEqual(rv.status_code, 400)
+        self.assertEqual(resp['error'], 'invalid_request')
 
         # If the client includes the 'client_secret' field in the request,
         # the value of this field MUST match the currently issued client
@@ -262,8 +262,8 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        assert rv.status_code == 400
-        assert resp['error'] == 'invalid_request'
+        self.assertEqual(rv.status_code, 400)
+        self.assertEqual(resp['error'], 'invalid_request')
 
     def test_invalid_client(self):
         # If the client does not exist on this server, the server MUST respond
@@ -278,8 +278,8 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        assert rv.status_code == 401
-        assert resp['error'] == 'invalid_client'
+        self.assertEqual(rv.status_code, 401)
+        self.assertEqual(resp['error'], 'invalid_client')
 
     def test_unauthorized_client(self):
         # If the client does not have permission to read its record, the server
@@ -303,8 +303,8 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        assert rv.status_code == 403
-        assert resp['error'] == 'unauthorized_client'
+        self.assertEqual(rv.status_code, 403)
+        self.assertEqual(resp['error'], 'unauthorized_client')
 
     def test_invalid_metadata(self):
         metadata = {'token_endpoint_auth_methods_supported': ['client_secret_basic']}
@@ -325,8 +325,8 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
         }
         rv = self.client.put('/configure_client/client_id', json=body, headers=headers)
         resp = json.loads(rv.data)
-        assert rv.status_code == 400
-        assert resp['error'] == 'invalid_client_metadata'
+        self.assertEqual(rv.status_code, 400)
+        self.assertEqual(resp['error'], 'invalid_client_metadata')
 
     def test_scopes_supported(self):
         metadata = {'scopes_supported': ['profile', 'email']}
@@ -340,9 +340,9 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
         }
         rv = self.client.put('/configure_client/client_id', json=body, headers=headers)
         resp = json.loads(rv.data)
-        assert resp['client_id'] == 'client_id'
-        assert resp['client_name'] == 'Authlib'
-        assert resp['scope'] == 'profile email'
+        self.assertEqual(resp['client_id'], 'client_id')
+        self.assertEqual(resp['client_name'], 'Authlib')
+        self.assertEqual(resp['scope'], 'profile email')
 
         headers = {'Authorization': f'bearer {token.access_token}'}
         body = {
@@ -352,8 +352,8 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
         }
         rv = self.client.put('/configure_client/client_id', json=body, headers=headers)
         resp = json.loads(rv.data)
-        assert resp['client_id'] == 'client_id'
-        assert resp['client_name'] == 'Authlib'
+        self.assertEqual(resp['client_id'], 'client_id')
+        self.assertEqual(resp['client_name'], 'Authlib')
 
         body = {
             'client_id': 'client_id',
@@ -362,7 +362,7 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
         }
         rv = self.client.put('/configure_client/client_id', json=body, headers=headers)
         resp = json.loads(rv.data)
-        assert resp['error'] in 'invalid_client_metadata'
+        self.assertIn(resp['error'], 'invalid_client_metadata')
 
     def test_response_types_supported(self):
         metadata = {'response_types_supported': ['code']}
@@ -376,9 +376,9 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
         }
         rv = self.client.put('/configure_client/client_id', json=body, headers=headers)
         resp = json.loads(rv.data)
-        assert resp['client_id'] == 'client_id'
-        assert resp['client_name'] == 'Authlib'
-        assert resp['response_types'] == ['code']
+        self.assertEqual(resp['client_id'], 'client_id')
+        self.assertEqual(resp['client_name'], 'Authlib')
+        self.assertEqual(resp['response_types'], ['code'])
 
         body = {
             'client_id': 'client_id',
@@ -387,7 +387,7 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
         }
         rv = self.client.put('/configure_client/client_id', json=body, headers=headers)
         resp = json.loads(rv.data)
-        assert resp['error'] in 'invalid_client_metadata'
+        self.assertIn(resp['error'], 'invalid_client_metadata')
 
     def test_grant_types_supported(self):
         metadata = {'grant_types_supported': ['authorization_code', 'password']}
@@ -401,9 +401,9 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
         }
         rv = self.client.put('/configure_client/client_id', json=body, headers=headers)
         resp = json.loads(rv.data)
-        assert resp['client_id'] == 'client_id'
-        assert resp['client_name'] == 'Authlib'
-        assert resp['grant_types'] == ['password']
+        self.assertEqual(resp['client_id'], 'client_id')
+        self.assertEqual(resp['client_name'], 'Authlib')
+        self.assertEqual(resp['grant_types'], ['password'])
 
         body = {
             'client_id': 'client_id',
@@ -412,7 +412,7 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
         }
         rv = self.client.put('/configure_client/client_id', json=body, headers=headers)
         resp = json.loads(rv.data)
-        assert resp['error'] in 'invalid_client_metadata'
+        self.assertIn(resp['error'], 'invalid_client_metadata')
 
     def test_token_endpoint_auth_methods_supported(self):
         metadata = {'token_endpoint_auth_methods_supported': ['client_secret_basic']}
@@ -426,9 +426,9 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
         }
         rv = self.client.put('/configure_client/client_id', json=body, headers=headers)
         resp = json.loads(rv.data)
-        assert resp['client_id'] == 'client_id'
-        assert resp['client_name'] == 'Authlib'
-        assert resp['token_endpoint_auth_method'] == 'client_secret_basic'
+        self.assertEqual(resp['client_id'], 'client_id')
+        self.assertEqual(resp['client_name'], 'Authlib')
+        self.assertEqual(resp['token_endpoint_auth_method'], 'client_secret_basic')
 
         body = {
             'client_id': 'client_id',
@@ -437,30 +437,30 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
         }
         rv = self.client.put('/configure_client/client_id', json=body, headers=headers)
         resp = json.loads(rv.data)
-        assert resp['error'] in 'invalid_client_metadata'
+        self.assertIn(resp['error'], 'invalid_client_metadata')
 
 
 class ClientConfigurationDeleteTest(ClientConfigurationTestMixin):
     def test_delete_client(self):
         user, client, token = self.prepare_data()
-        assert client.client_name == 'Authlib'
+        self.assertEqual(client.client_name, 'Authlib')
         headers = {'Authorization': f'bearer {token.access_token}'}
         rv = self.client.delete('/configure_client/client_id', headers=headers)
-        assert rv.status_code == 204
-        assert not rv.data
+        self.assertEqual(rv.status_code, 204)
+        self.assertFalse(rv.data)
 
     def test_access_denied(self):
         user, client, token = self.prepare_data()
         rv = self.client.delete('/configure_client/client_id')
         resp = json.loads(rv.data)
-        assert rv.status_code == 400
-        assert resp['error'] == 'access_denied'
+        self.assertEqual(rv.status_code, 400)
+        self.assertEqual(resp['error'], 'access_denied')
 
         headers = {'Authorization': f'bearer invalid_token'}
         rv = self.client.delete('/configure_client/client_id', headers=headers)
         resp = json.loads(rv.data)
-        assert rv.status_code == 400
-        assert resp['error'] == 'access_denied'
+        self.assertEqual(rv.status_code, 400)
+        self.assertEqual(resp['error'], 'access_denied')
 
         headers = {'Authorization': f'bearer unauthorized_token'}
         rv = self.client.delete(
@@ -469,8 +469,8 @@ class ClientConfigurationDeleteTest(ClientConfigurationTestMixin):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        assert rv.status_code == 400
-        assert resp['error'] == 'access_denied'
+        self.assertEqual(rv.status_code, 400)
+        self.assertEqual(resp['error'], 'access_denied')
 
     def test_invalid_client(self):
         # If the client does not exist on this server, the server MUST respond
@@ -481,8 +481,8 @@ class ClientConfigurationDeleteTest(ClientConfigurationTestMixin):
         headers = {'Authorization': f'bearer {token.access_token}'}
         rv = self.client.delete('/configure_client/invalid_client_id', headers=headers)
         resp = json.loads(rv.data)
-        assert rv.status_code == 401
-        assert resp['error'] == 'invalid_client'
+        self.assertEqual(rv.status_code, 401)
+        self.assertEqual(resp['error'], 'invalid_client')
 
     def test_unauthorized_client(self):
         # If the client does not have permission to read its record, the server
@@ -501,5 +501,5 @@ class ClientConfigurationDeleteTest(ClientConfigurationTestMixin):
             '/configure_client/unauthorized_client_id', headers=headers
         )
         resp = json.loads(rv.data)
-        assert rv.status_code == 403
-        assert resp['error'] == 'unauthorized_client'
+        self.assertEqual(rv.status_code, 403)
+        self.assertEqual(resp['error'], 'unauthorized_client')

--- a/tests/flask/test_oauth2/test_client_configuration_endpoint.py
+++ b/tests/flask/test_oauth2/test_client_configuration_endpoint.py
@@ -1,0 +1,505 @@
+from flask import json
+from authlib.common.security import generate_token
+from authlib.jose import jwt
+from authlib.oauth2.rfc7591.claims import ClientMetadataClaims
+from authlib.oauth2.rfc7592 import (
+    ClientConfigurationEndpoint as _ClientConfigurationEndpoint,
+)
+from tests.util import read_file_path
+from .models import db, User, Client, Token
+from .oauth2_server import TestCase
+from .oauth2_server import create_authorization_server
+
+
+class ClientConfigurationEndpoint(_ClientConfigurationEndpoint):
+    software_statement_alg_values_supported = ["RS256"]
+
+    def authenticate_token(self, request):
+        auth_header = request.headers.get("Authorization")
+        if auth_header:
+            access_token = auth_header.split()[1]
+            return Token.query.filter_by(access_token=access_token).first()
+
+    def update_client(self, client, client_metadata, request):
+        client.set_client_metadata({**client.client_metadata, **client_metadata})
+        db.session.add(client)
+        db.session.commit()
+        return client
+
+    def authenticate_client(self, request):
+        client_id = request.uri.split("/")[-1]
+        return Client.query.filter_by(client_id=client_id).first()
+
+    def revoke_access_token(self, request):
+        request.credential.revoked = True
+
+    def check_permission(self, client, request):
+        client_id = request.uri.split("/")[-1]
+        return client_id != "unauthorized_client_id"
+
+    def delete_client(self, client, request):
+        db.session.delete(client)
+        db.session.commit()
+
+    def generate_client_registration_info(self, client, request):
+        return {
+            "registration_client_uri": request.uri,
+            "registration_access_token": request.headers["Authorization"].split(" ")[1],
+        }
+
+
+class ClientConfigurationTestMixin(TestCase):
+    def prepare_data(self, endpoint_cls=None, metadata=None):
+        app = self.app
+        server = create_authorization_server(app)
+
+        if endpoint_cls:
+            server.register_endpoint(endpoint_cls)
+        else:
+
+            class MyClientConfiguration(ClientConfigurationEndpoint):
+                def get_server_metadata(self):
+                    return metadata
+
+            server.register_endpoint(MyClientConfiguration)
+
+        @app.route("/configure_client/<client_id>", methods=["PUT", "GET", "DELETE"])
+        def configure_client(client_id):
+            return server.create_endpoint_response(
+                ClientConfigurationEndpoint.ENDPOINT_NAME
+            )
+
+        user = User(username="foo")
+        db.session.add(user)
+
+        client = Client(
+            client_id="client_id",
+            client_secret="client_secret",
+        )
+        client.set_client_metadata(
+            {
+                "client_name": "Authlib",
+                "scope": "openid profile",
+            }
+        )
+        db.session.add(client)
+
+        token = Token(
+            user_id=user.id,
+            client_id=client.id,
+            token_type="bearer",
+            access_token="a1",
+            refresh_token="r1",
+            scope="openid profile",
+            expires_in=3600,
+        )
+        db.session.add(token)
+
+        db.session.commit()
+        return user, client, token
+
+
+class ClientConfigurationReadTest(ClientConfigurationTestMixin):
+    def test_read_client(self):
+        user, client, token = self.prepare_data()
+        assert client.client_name == "Authlib"
+        headers = {"Authorization": f"bearer {token.access_token}"}
+        rv = self.client.get("/configure_client/client_id", headers=headers)
+        resp = json.loads(rv.data)
+        assert rv.status_code == 200
+        assert resp["client_id"] == client.client_id
+        assert resp["client_name"] == "Authlib"
+        assert (
+            resp["registration_client_uri"]
+            == "http://localhost/configure_client/client_id"
+        )
+        assert resp["registration_access_token"] == token.access_token
+
+    def test_access_denied(self):
+        user, client, token = self.prepare_data()
+        rv = self.client.get("/configure_client/client_id")
+        resp = json.loads(rv.data)
+        assert rv.status_code == 400
+        assert resp["error"] == "access_denied"
+
+        headers = {"Authorization": f"bearer invalid_token"}
+        rv = self.client.get("/configure_client/client_id", headers=headers)
+        resp = json.loads(rv.data)
+        assert rv.status_code == 400
+        assert resp["error"] == "access_denied"
+
+        headers = {"Authorization": f"bearer unauthorized_token"}
+        rv = self.client.get(
+            "/configure_client/client_id",
+            json={"client_id": "client_id", "client_name": "new client_name"},
+            headers=headers,
+        )
+        resp = json.loads(rv.data)
+        assert rv.status_code == 400
+        assert resp["error"] == "access_denied"
+
+    def test_invalid_client(self):
+        # If the client does not exist on this server, the server MUST respond
+        # with HTTP 401 Unauthorized, and the registration access token used to
+        # make this request SHOULD be immediately revoked.
+        user, client, token = self.prepare_data()
+
+        headers = {"Authorization": f"bearer {token.access_token}"}
+        rv = self.client.get("/configure_client/invalid_client_id", headers=headers)
+        resp = json.loads(rv.data)
+        assert rv.status_code == 401
+        assert resp["error"] == "invalid_client"
+
+    def test_unauthorized_client(self):
+        # If the client does not have permission to read its record, the server
+        # MUST return an HTTP 403 Forbidden.
+
+        client = Client(
+            client_id="unauthorized_client_id",
+            client_secret="unauthorized_client_secret",
+        )
+        db.session.add(client)
+
+        user, client, token = self.prepare_data()
+
+        headers = {"Authorization": f"bearer {token.access_token}"}
+        rv = self.client.get(
+            "/configure_client/unauthorized_client_id", headers=headers
+        )
+        resp = json.loads(rv.data)
+        assert rv.status_code == 403
+        assert resp["error"] == "unauthorized_client"
+
+
+class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
+    def test_update_client(self):
+        # Valid values of client metadata fields in this request MUST replace,
+        # not augment, the values previously associated with this client.
+        # Omitted fields MUST be treated as null or empty values by the server,
+        # indicating the client's request to delete them from the client's
+        # registration.  The authorization server MAY ignore any null or empty
+        # value in the request just as any other value.
+
+        user, client, token = self.prepare_data()
+        assert client.client_name == "Authlib"
+        headers = {"Authorization": f"bearer {token.access_token}"}
+        body = {
+            "client_id": client.client_id,
+            "client_name": "NewAuthlib",
+        }
+        rv = self.client.put("/configure_client/client_id", json=body, headers=headers)
+        resp = json.loads(rv.data)
+        assert rv.status_code == 200
+        assert resp["client_id"] == client.client_id
+        assert resp["client_name"] == "NewAuthlib"
+        assert client.client_name == "NewAuthlib"
+        assert client.scope == "openid profile"
+
+    def test_access_denied(self):
+        user, client, token = self.prepare_data()
+        rv = self.client.put("/configure_client/client_id", json={})
+        resp = json.loads(rv.data)
+        assert rv.status_code == 400
+        assert resp["error"] == "access_denied"
+
+        headers = {"Authorization": f"bearer invalid_token"}
+        rv = self.client.put("/configure_client/client_id", json={}, headers=headers)
+        resp = json.loads(rv.data)
+        assert rv.status_code == 400
+        assert resp["error"] == "access_denied"
+
+        headers = {"Authorization": f"bearer unauthorized_token"}
+        rv = self.client.put(
+            "/configure_client/client_id",
+            json={"client_id": "client_id", "client_name": "new client_name"},
+            headers=headers,
+        )
+        resp = json.loads(rv.data)
+        assert rv.status_code == 400
+        assert resp["error"] == "access_denied"
+
+    def test_invalid_request(self):
+        user, client, token = self.prepare_data()
+        headers = {"Authorization": f"bearer {token.access_token}"}
+
+        # The client MUST include its "client_id" field in the request...
+        rv = self.client.put("/configure_client/client_id", json={}, headers=headers)
+        resp = json.loads(rv.data)
+        assert rv.status_code == 400
+        assert resp["error"] == "invalid_request"
+
+        # ... and it MUST be the same as its currently issued client identifier.
+        rv = self.client.put(
+            "/configure_client/client_id",
+            json={"client_id": "invalid_client_id"},
+            headers=headers,
+        )
+        resp = json.loads(rv.data)
+        assert rv.status_code == 400
+        assert resp["error"] == "invalid_request"
+
+        # The updated client metadata fields request MUST NOT include the
+        # "registration_access_token", "registration_client_uri",
+        # "client_secret_expires_at", or "client_id_issued_at" fields
+        rv = self.client.put(
+            "/configure_client/client_id",
+            json={
+                "client_id": "client_id",
+                "registration_client_uri": "https://foobar.com",
+            },
+            headers=headers,
+        )
+        resp = json.loads(rv.data)
+        assert rv.status_code == 400
+        assert resp["error"] == "invalid_request"
+
+        # If the client includes the "client_secret" field in the request,
+        # the value of this field MUST match the currently issued client
+        # secret for that client.
+        rv = self.client.put(
+            "/configure_client/client_id",
+            json={"client_id": "client_id", "client_secret": "invalid_secret"},
+            headers=headers,
+        )
+        resp = json.loads(rv.data)
+        assert rv.status_code == 400
+        assert resp["error"] == "invalid_request"
+
+    def test_invalid_client(self):
+        # If the client does not exist on this server, the server MUST respond
+        # with HTTP 401 Unauthorized, and the registration access token used to
+        # make this request SHOULD be immediately revoked.
+        user, client, token = self.prepare_data()
+
+        headers = {"Authorization": f"bearer {token.access_token}"}
+        rv = self.client.put(
+            "/configure_client/invalid_client_id",
+            json={"client_id": "invalid_client_id", "client_name": "new client_name"},
+            headers=headers,
+        )
+        resp = json.loads(rv.data)
+        assert rv.status_code == 401
+        assert resp["error"] == "invalid_client"
+
+    def test_unauthorized_client(self):
+        # If the client does not have permission to read its record, the server
+        # MUST return an HTTP 403 Forbidden.
+
+        client = Client(
+            client_id="unauthorized_client_id",
+            client_secret="unauthorized_client_secret",
+        )
+        db.session.add(client)
+
+        user, client, token = self.prepare_data()
+
+        headers = {"Authorization": f"bearer {token.access_token}"}
+        rv = self.client.put(
+            "/configure_client/unauthorized_client_id",
+            json={
+                "client_id": "unauthorized_client_id",
+                "client_name": "new client_name",
+            },
+            headers=headers,
+        )
+        resp = json.loads(rv.data)
+        assert rv.status_code == 403
+        assert resp["error"] == "unauthorized_client"
+
+    def test_invalid_metadata(self):
+        metadata = {"token_endpoint_auth_methods_supported": ["client_secret_basic"]}
+        user, client, token = self.prepare_data(metadata=metadata)
+        headers = {"Authorization": f"bearer {token.access_token}"}
+
+        # For all metadata fields, the authorization server MAY replace any
+        # invalid values with suitable default values, and it MUST return any
+        # such fields to the client in the response.
+        # If the client attempts to set an invalid metadata field and the
+        # authorization server does not set a default value, the authorization
+        # server responds with an error as described in [RFC7591].
+
+        body = {
+            "client_id": client.client_id,
+            "client_name": "NewAuthlib",
+            "token_endpoint_auth_method": "invalid_auth_method",
+        }
+        rv = self.client.put("/configure_client/client_id", json=body, headers=headers)
+        resp = json.loads(rv.data)
+        assert rv.status_code == 400
+        assert resp["error"] == "invalid_client_metadata"
+
+    def test_scopes_supported(self):
+        metadata = {"scopes_supported": ["profile", "email"]}
+        user, client, token = self.prepare_data(metadata=metadata)
+
+        headers = {"Authorization": f"bearer {token.access_token}"}
+        body = {
+            "client_id": "client_id",
+            "scope": "profile email",
+            "client_name": "Authlib",
+        }
+        rv = self.client.put("/configure_client/client_id", json=body, headers=headers)
+        resp = json.loads(rv.data)
+        assert resp["client_id"] == "client_id"
+        assert resp["client_name"] == "Authlib"
+        assert resp["scope"] == "profile email"
+
+        headers = {"Authorization": f"bearer {token.access_token}"}
+        body = {
+            "client_id": "client_id",
+            "scope": "",
+            "client_name": "Authlib",
+        }
+        rv = self.client.put("/configure_client/client_id", json=body, headers=headers)
+        resp = json.loads(rv.data)
+        assert resp["client_id"] == "client_id"
+        assert resp["client_name"] == "Authlib"
+
+        body = {
+            "client_id": "client_id",
+            "scope": "profile email address",
+            "client_name": "Authlib",
+        }
+        rv = self.client.put("/configure_client/client_id", json=body, headers=headers)
+        resp = json.loads(rv.data)
+        assert resp["error"] in "invalid_client_metadata"
+
+    def test_response_types_supported(self):
+        metadata = {"response_types_supported": ["code"]}
+        user, client, token = self.prepare_data(metadata=metadata)
+
+        headers = {"Authorization": f"bearer {token.access_token}"}
+        body = {
+            "client_id": "client_id",
+            "response_types": ["code"],
+            "client_name": "Authlib",
+        }
+        rv = self.client.put("/configure_client/client_id", json=body, headers=headers)
+        resp = json.loads(rv.data)
+        assert resp["client_id"] == "client_id"
+        assert resp["client_name"] == "Authlib"
+        assert resp["response_types"] == ["code"]
+
+        body = {
+            "client_id": "client_id",
+            "response_types": ["code", "token"],
+            "client_name": "Authlib",
+        }
+        rv = self.client.put("/configure_client/client_id", json=body, headers=headers)
+        resp = json.loads(rv.data)
+        assert resp["error"] in "invalid_client_metadata"
+
+    def test_grant_types_supported(self):
+        metadata = {"grant_types_supported": ["authorization_code", "password"]}
+        user, client, token = self.prepare_data(metadata=metadata)
+
+        headers = {"Authorization": f"bearer {token.access_token}"}
+        body = {
+            "client_id": "client_id",
+            "grant_types": ["password"],
+            "client_name": "Authlib",
+        }
+        rv = self.client.put("/configure_client/client_id", json=body, headers=headers)
+        resp = json.loads(rv.data)
+        assert resp["client_id"] == "client_id"
+        assert resp["client_name"] == "Authlib"
+        assert resp["grant_types"] == ["password"]
+
+        body = {
+            "client_id": "client_id",
+            "grant_types": ["client_credentials"],
+            "client_name": "Authlib",
+        }
+        rv = self.client.put("/configure_client/client_id", json=body, headers=headers)
+        resp = json.loads(rv.data)
+        assert resp["error"] in "invalid_client_metadata"
+
+    def test_token_endpoint_auth_methods_supported(self):
+        metadata = {"token_endpoint_auth_methods_supported": ["client_secret_basic"]}
+        user, client, token = self.prepare_data(metadata=metadata)
+
+        headers = {"Authorization": f"bearer {token.access_token}"}
+        body = {
+            "client_id": "client_id",
+            "token_endpoint_auth_method": "client_secret_basic",
+            "client_name": "Authlib",
+        }
+        rv = self.client.put("/configure_client/client_id", json=body, headers=headers)
+        resp = json.loads(rv.data)
+        assert resp["client_id"] == "client_id"
+        assert resp["client_name"] == "Authlib"
+        assert resp["token_endpoint_auth_method"] == "client_secret_basic"
+
+        body = {
+            "client_id": "client_id",
+            "token_endpoint_auth_method": "none",
+            "client_name": "Authlib",
+        }
+        rv = self.client.put("/configure_client/client_id", json=body, headers=headers)
+        resp = json.loads(rv.data)
+        assert resp["error"] in "invalid_client_metadata"
+
+
+class ClientConfigurationDeleteTest(ClientConfigurationTestMixin):
+    def test_delete_client(self):
+        user, client, token = self.prepare_data()
+        assert client.client_name == "Authlib"
+        headers = {"Authorization": f"bearer {token.access_token}"}
+        rv = self.client.delete("/configure_client/client_id", headers=headers)
+        assert rv.status_code == 204
+        assert not rv.data
+
+    def test_access_denied(self):
+        user, client, token = self.prepare_data()
+        rv = self.client.delete("/configure_client/client_id")
+        resp = json.loads(rv.data)
+        assert rv.status_code == 400
+        assert resp["error"] == "access_denied"
+
+        headers = {"Authorization": f"bearer invalid_token"}
+        rv = self.client.delete("/configure_client/client_id", headers=headers)
+        resp = json.loads(rv.data)
+        assert rv.status_code == 400
+        assert resp["error"] == "access_denied"
+
+        headers = {"Authorization": f"bearer unauthorized_token"}
+        rv = self.client.delete(
+            "/configure_client/client_id",
+            json={"client_id": "client_id", "client_name": "new client_name"},
+            headers=headers,
+        )
+        resp = json.loads(rv.data)
+        assert rv.status_code == 400
+        assert resp["error"] == "access_denied"
+
+    def test_invalid_client(self):
+        # If the client does not exist on this server, the server MUST respond
+        # with HTTP 401 Unauthorized, and the registration access token used to
+        # make this request SHOULD be immediately revoked.
+        user, client, token = self.prepare_data()
+
+        headers = {"Authorization": f"bearer {token.access_token}"}
+        rv = self.client.delete("/configure_client/invalid_client_id", headers=headers)
+        resp = json.loads(rv.data)
+        assert rv.status_code == 401
+        assert resp["error"] == "invalid_client"
+
+    def test_unauthorized_client(self):
+        # If the client does not have permission to read its record, the server
+        # MUST return an HTTP 403 Forbidden.
+
+        client = Client(
+            client_id="unauthorized_client_id",
+            client_secret="unauthorized_client_secret",
+        )
+        db.session.add(client)
+
+        user, client, token = self.prepare_data()
+
+        headers = {"Authorization": f"bearer {token.access_token}"}
+        rv = self.client.delete(
+            "/configure_client/unauthorized_client_id", headers=headers
+        )
+        resp = json.loads(rv.data)
+        assert rv.status_code == 403
+        assert resp["error"] == "unauthorized_client"


### PR DESCRIPTION
This PR fixes/implements the RFC7592 spec. It brings those changes

- The Flask integration keep the request data when the request type is `PUT`
- rfc7592/endpoint.py implements the RFC7592 specification
- The endpoint is tested by tests/flask/test_oauth2/test_client_configuration_endpoint.py
- rfc7592/endpoint.py has a 100% coverage
- The implementation is documented by docs/specs/rfc7592.rst

I read RFC7592 and did my best to implement this, but I am not 100% confident to have understood or implemented things right. I think a second pair of eyes might help. I tried to make unit tests as explicit and short as I could, and insert quotes from the spec to illustrate the tests.

The `extract_client_metadata` method has been copied from RFC7591 (and I removed the `software_statement` part). Maybe this should be factorized? If so, how should this be? I was thinking of extracting the method in a `ClientRegistrationEndpointMixin` from which would inherit `ClientRegistrationEndpoint` and `ClientConfigurationEndpoint`.

There are breaking changes on some method signatures, but this spec was not documented anyways:

- `introspect_client` MUST be implemented
- `save_client` is renamed `update_client` and takes an additional `client_metadata` parameter
- `introspect_metadata` is not required anymore
- `revoke_access_token` takes a `token` parameter

I think the documentation could make clearer that a *registration access token* can be a different thing than a regular *access_token*, but I guess this is enough like this.

Fixes #499

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
