### PR TITLE
RFC7591: Use default values for 'response_types' and 'grant_types'

### DIFF
--- a/authlib/oauth2/rfc7591/endpoint.py
+++ b/authlib/oauth2/rfc7591/endpoint.py
@@ -108,7 +108,10 @@ class ClientRegistrationEndpoint(object):
             response_types_supported = set(response_types_supported)
 
             def _validate_response_types(claims, value):
-                return response_types_supported.issuperset(set(value))
+                # If omitted, the default is that the client will use only the "code"
+                # response type.
+                response_types = set(value) if value else {"code"}
+                return response_types_supported.issuperset(response_types)
 
             options['response_types'] = {'validate': _validate_response_types}
 
@@ -116,7 +119,10 @@ class ClientRegistrationEndpoint(object):
             grant_types_supported = set(grant_types_supported)
 
             def _validate_grant_types(claims, value):
-                return grant_types_supported.issuperset(set(value))
+                # If omitted, the default behavior is that the client will use only
+                # the "authorization_code" Grant Type.
+                grant_types = set(value) if value else {"authorization_code"}
+                return grant_types_supported.issuperset(grant_types)
 
             options['grant_types'] = {'validate': _validate_grant_types}
 

--- a/authlib/oauth2/rfc7592/endpoint.py
+++ b/authlib/oauth2/rfc7592/endpoint.py
@@ -138,7 +138,10 @@ class ClientConfigurationEndpoint(object):
             response_types_supported = set(response_types_supported)
 
             def _validate_response_types(claims, value):
-                return response_types_supported.issuperset(set(value))
+                # If omitted, the default is that the client will use only the "code"
+                # response type.
+                response_types = set(value) if value else {"code"}
+                return response_types_supported.issuperset(response_types)
 
             options['response_types'] = {'validate': _validate_response_types}
 
@@ -146,7 +149,10 @@ class ClientConfigurationEndpoint(object):
             grant_types_supported = set(grant_types_supported)
 
             def _validate_grant_types(claims, value):
-                return grant_types_supported.issuperset(set(value))
+                # If omitted, the default behavior is that the client will use only
+                # the "authorization_code" Grant Type.
+                grant_types = set(value) if value else {"authorization_code"}
+                return grant_types_supported.issuperset(grant_types)
 
             options['grant_types'] = {'validate': _validate_grant_types}
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 
 Here you can see the full list of changes between each Authlib release.
 
+Version x.x.x
+-------------
+
+- Fixed RFC7591 and RFC7592 ``grant_types`` and ``response_types`` default values, via :gh:`PR#509`.
+
 Version 1.2.0
 -------------
 

--- a/tests/flask/test_oauth2/test_client_registration_endpoint.py
+++ b/tests/flask/test_oauth2/test_client_registration_endpoint.py
@@ -137,6 +137,15 @@ class ClientRegistrationTest(TestCase):
         self.assertIn('client_id', resp)
         self.assertEqual(resp['client_name'], 'Authlib')
 
+        # https://www.rfc-editor.org/rfc/rfc7591.html#section-2
+        # If omitted, the default is that the client will use only the "code"
+        # response type.
+        body = {'client_name': 'Authlib'}
+        rv = self.client.post('/create_client', json=body, headers=headers)
+        resp = json.loads(rv.data)
+        self.assertIn('client_id', resp)
+        self.assertEqual(resp['client_name'], 'Authlib')
+
         body = {'response_types': ['code', 'token'], 'client_name': 'Authlib'}
         rv = self.client.post('/create_client', json=body, headers=headers)
         resp = json.loads(rv.data)
@@ -148,6 +157,15 @@ class ClientRegistrationTest(TestCase):
 
         headers = {'Authorization': 'bearer abc'}
         body = {'grant_types': ['password'], 'client_name': 'Authlib'}
+        rv = self.client.post('/create_client', json=body, headers=headers)
+        resp = json.loads(rv.data)
+        self.assertIn('client_id', resp)
+        self.assertEqual(resp['client_name'], 'Authlib')
+
+        # https://www.rfc-editor.org/rfc/rfc7591.html#section-2
+        # If omitted, the default behavior is that the client will use only
+        # the "authorization_code" Grant Type.
+        body = {'client_name': 'Authlib'}
         rv = self.client.post('/create_client', json=body, headers=headers)
         resp = json.loads(rv.data)
         self.assertIn('client_id', resp)


### PR DESCRIPTION
The [RFC7591 dynamic client registration](https://www.rfc-editor.org/rfc/rfc7591.html#section-2) indicates default values for `response_types` and `grant_types`:
- If omitted, the default is that the client will use only the "code" response type.
- If omitted, the default behavior is that the client will use only the "authorization_code" Grant Type.
 
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No
---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
