### PR TITLE
Add support for default timeout in OAuth2Session

### DIFF
--- a/authlib/integrations/requests_client/oauth2_session.py
+++ b/authlib/integrations/requests_client/oauth2_session.py
@@ -80,6 +80,7 @@ class OAuth2Session(OAuth2Client, Session):
                  token=None, token_placement='header',
                  update_token=None, **kwargs):
 
+        self.default_timeout = kwargs.get('timeout')
         Session.__init__(self)
         update_session_configure(self, kwargs)
 
@@ -99,6 +100,7 @@ class OAuth2Session(OAuth2Client, Session):
 
     def request(self, method, url, withhold_token=False, auth=None, **kwargs):
         """Send request with auto refresh token feature (if available)."""
+        kwargs['timeout'] = kwargs.get('timeout') or self.default_timeout
         if not withhold_token and auth is None:
             if not self.token:
                 raise MissingTokenError()

--- a/tests/clients/test_requests/test_oauth2_session.py
+++ b/tests/clients/test_requests/test_oauth2_session.py
@@ -506,3 +506,40 @@ class OAuth2SessionTest(TestCase):
         sess = requests.Session()
         sess.send = verifier
         sess.get('https://i.b', auth=client.token_auth)
+
+    def test_use_default_request_timeout(self):
+        expected_timeout = 10
+
+        def verifier(r, **kwargs):
+            timeout = kwargs.get('timeout')
+            self.assertEqual(timeout, expected_timeout)
+            resp = mock.MagicMock()
+            return resp
+
+        client = OAuth2Session(
+            client_id=self.client_id,
+            token=self.token,
+            timeout=expected_timeout,
+        )
+
+        client.send = verifier
+        client.request('GET', 'https://i.b', withhold_token=False)
+
+    def test_override_default_request_timeout(self):
+        default_timeout = 15
+        expected_timeout = 10
+
+        def verifier(r, **kwargs):
+            timeout = kwargs.get('timeout')
+            self.assertEqual(timeout, expected_timeout)
+            resp = mock.MagicMock()
+            return resp
+
+        client = OAuth2Session(
+            client_id=self.client_id,
+            token=self.token,
+            timeout=default_timeout,
+        )
+
+        client.send = verifier
+        client.request('GET', 'https://i.b', withhold_token=False, timeout=expected_timeout)


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.

This is related to #451 - It resolves the issue that it's not possible to send a timeout when fetching server meta data or jwk keys. 

This fix uses a default timeout on every request, when timeout is provided to the `OAuth2Session`. 

If you have a different way you'd prefer to propagate timeout to the request please let me know, would be happy to amend accordingly.
