### PR TITLE
Removed `has_client_secret` method.

### DIFF
--- a/authlib/integrations/sqla_oauth2/client_mixin.py
+++ b/authlib/integrations/sqla_oauth2/client_mixin.py
@@ -122,9 +122,6 @@ class OAuth2ClientMixin(ClientMixin):
     def check_redirect_uri(self, redirect_uri):
         return redirect_uri in self.redirect_uris
 
-    def has_client_secret(self):
-        return bool(self.client_secret)
-
     def check_client_secret(self, client_secret):
         return secrets.compare_digest(self.client_secret, client_secret)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 
 Here you can see the full list of changes between each Authlib release.
 
+Version x.x.x
+-------------
+
+- Removed ``has_client_secret`` method and documentation, via :gh:`PR#513`
+
 Version 1.2.0
 -------------
 

--- a/docs/django/2/authorization-server.rst
+++ b/docs/django/2/authorization-server.rst
@@ -72,9 +72,6 @@ the missing methods of :class:`~authlib.oauth2.rfc6749.ClientMixin`::
                 return True
             return redirect_uri in self.redirect_uris
 
-        def has_client_secret(self):
-            return bool(self.client_secret)
-
         def check_client_secret(self, client_secret):
             return self.client_secret == client_secret
 

--- a/tests/django/test_oauth2/models.py
+++ b/tests/django/test_oauth2/models.py
@@ -49,9 +49,6 @@ class Client(Model, ClientMixin):
             return True
         return redirect_uri in self.redirect_uris
 
-    def has_client_secret(self):
-        return bool(self.client_secret)
-
     def check_client_secret(self, client_secret):
         return self.client_secret == client_secret
 


### PR DESCRIPTION
I just noticed that `has_client_secret` is unused.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
