### PR TITLE
jws: correctly handle empty payload with JSON serialization

### DIFF
--- a/authlib/jose/rfc7515/jws.py
+++ b/authlib/jose/rfc7515/jws.py
@@ -168,7 +168,7 @@ class JsonWebSignature(object):
         obj = ensure_dict(obj, 'JWS')
 
         payload_segment = obj.get('payload')
-        if not payload_segment:
+        if payload_segment is None:
             raise DecodeError('Missing "payload" value')
 
         payload_segment = to_bytes(payload_segment)

--- a/tests/jose/test_jws.py
+++ b/tests/jose/test_jws.py
@@ -154,6 +154,14 @@ class JWSTest(unittest.TestCase):
         self.assertEqual(header[0]['alg'], 'HS256')
         self.assertNotIn('signature', data)
 
+    def test_serialize_json_empty_payload(self):
+        jws = JsonWebSignature()
+        protected = {'alg': 'HS256'}
+        header = {'protected': protected, 'header': {'kid': 'a'}}
+        s = jws.serialize_json(header, b'', 'secret')
+        data = jws.deserialize_json(s, 'secret')
+        self.assertEqual(data['payload'], b'')
+
     def test_fail_deserialize_json(self):
         jws = JsonWebSignature()
         self.assertRaises(errors.DecodeError, jws.deserialize_json, None, '')


### PR DESCRIPTION
Previously the code checked if the payload value was True when converted to bool by the if statement, but that conflates None (i.e., no payload field in the JSON serialization) and the empty string (a specific payload), because both are False when converted to bool.  The proper check (as verified by the added test case) is to check if the payload is None.

**What kind of change does this PR introduce?** (check at least one)

- [ X ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

---

- [ X ] You consent that the copyright of your pull request source code belongs to Authlib's author.
