### PR TITLE
Starlette v0.26.0 support and authorize_redirect fix

### DIFF
--- a/authlib/integrations/starlette_client/apps.py
+++ b/authlib/integrations/starlette_client/apps.py
@@ -1,3 +1,4 @@
+from starlette.datastructures import URL
 from starlette.responses import RedirectResponse
 from ..base_client import OAuthError
 from ..base_client import BaseApp
@@ -26,6 +27,10 @@ class StarletteAppMixin(object):
         :param kwargs: Extra parameters to include.
         :return: A HTTP redirect response.
         """
+
+        # Handle Starlette >= 0.26.0 where redirect_uri may now be a URL and not a string
+        if redirect_uri and isinstance(redirect_uri, URL):
+            redirect_uri = str(redirect_uri)
         rv = await self.create_authorization_url(redirect_uri, **kwargs)
         await self.save_authorize_data(request, redirect_uri=redirect_uri, **rv)
         return RedirectResponse(rv['url'], status_code=302)


### PR DESCRIPTION
Starlette `0.26.0` changed the return value of `url_for()` from `str` to `URL`; see https://github.com/encode/starlette/pull/1385 for context.

Passing a `redirect_uri` to `authorize_redirect` causes a `TypeError: cannot convert 'URL' object to bytes` exception to be raised if the URL has been generated via `url_for()`. This fix detects an instance of `URL` and casts it to a string, thus allowing authentication to proceed and generally making people happy.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
