### PR TITLE
Allow falsey but non-None grant uri params

### DIFF
--- a/authlib/oauth2/rfc6749/parameters.py
+++ b/authlib/oauth2/rfc6749/parameters.py
@@ -60,7 +60,7 @@ def prepare_grant_uri(uri, client_id, response_type, redirect_uri=None,
         params.append(('state', state))
 
     for k in kwargs:
-        if kwargs[k]:
+        if kwargs[k] is not None:
             params.append((to_unicode(k), kwargs[k]))
 
     return add_params_to_uri(uri, params)

--- a/tests/core/test_oauth2/test_rfc6749_misc.py
+++ b/tests/core/test_oauth2/test_rfc6749_misc.py
@@ -50,6 +50,13 @@ class OAuth2ParametersTest(unittest.TestCase):
             rv,
             {'access_token': 'a', 'token_type': 'bearer', 'state': 'c'}
         )
+    
+    def test_prepare_grant_uri(self):
+        grant_uri = parameters.prepare_grant_uri('https://i.b/authorize', 'dev', 'code', max_age=0)
+        self.assertEqual(
+            grant_uri,
+            "https://i.b/authorize?response_type=code&client_id=dev&max_age=0"
+        )
 
 
 class OAuth2UtilTest(unittest.TestCase):


### PR DESCRIPTION
There are use cases where you want to pass `0` to `authorize_redirect`, for example Auth0 allows you to force login again by passing `max_age=0`, as described [here](https://auth0.com/docs/authenticate/login/max-age-reauthentication).

The current code for `prepare_grant_uri` filters out such parameters. This PR changes that to explicitly filter out `None` instead.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

Debatable? Technically a breaking change if someone was passing a non-`None` falsey value to `authorize_redirect()` previously.

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
