### PR TITLE
Auto refresh token for detected client_credentials grant type

### DIFF
--- a/authlib/oauth2/client.py
+++ b/authlib/oauth2/client.py
@@ -193,6 +193,10 @@ class OAuth2Client(object):
         if grant_type is None:
             grant_type = self.metadata.get('grant_type')
 
+        if grant_type is None:
+            grant_type = _guess_grant_type(kwargs)
+            self.metadata['grant_type'] = grant_type
+
         body = self._prepare_token_endpoint_body(body, grant_type, **kwargs)
 
         if auth is None:
@@ -401,9 +405,6 @@ class OAuth2Client(object):
             url, body, auth=auth, headers=headers, **session_kwargs)
 
     def _prepare_token_endpoint_body(self, body, grant_type, **kwargs):
-        if grant_type is None:
-            grant_type = _guess_grant_type(kwargs)
-
         if grant_type == 'authorization_code':
             if 'redirect_uri' not in kwargs:
                 kwargs['redirect_uri'] = self.redirect_uri


### PR DESCRIPTION
When the `OAuth2Client` is not constructed explicitly with `grant_type='client_credentials'`, fetching the initial token works (due to the auto-detection of `client_credentials` in `_guess_grant_type`) but it then fails to auto-refresh the token (due to the check [here](https://github.com/lepture/authlib/blob/70a6bfa92aa1007515465a7af1a60a4518abe699/authlib/oauth2/client.py#L264)).

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
