### PR TITLE
HTTPX: add send method

### DIFF
--- a/authlib/integrations/httpx_client/oauth2_client.py
+++ b/authlib/integrations/httpx_client/oauth2_client.py
@@ -104,6 +104,17 @@ class AsyncOAuth2Client(_OAuth2Client, httpx.AsyncClient):
             method, url, auth=auth, **kwargs) as resp:
             yield resp
 
+    def send(self, req, withhold_token=False, auth=USE_CLIENT_DEFAULT, **kwargs):
+        if not withhold_token and auth is USE_CLIENT_DEFAULT:
+            if not self.token:
+                raise MissingTokenError()
+
+            self.ensure_active_token(self.token)
+
+            auth = self.token_auth
+
+        return super(AsyncOAuth2Client, self).send(req, auth=auth, **kwargs)
+
     async def ensure_active_token(self, token):
         async with self._token_refresh_lock:
             if self.token.is_expired():


### PR DESCRIPTION
Hello,
Thank you for this library.
In some cases documented by [HTTPX](https://www.python-httpx.org/advanced/#request-instances), when using directly the `send` method, the bearer token is not passed.
This change adds a method with a similar signature to `request` and `stream` with an auth parameter.

The only thing I have not fully tested is `self.ensure_active_token(self.token)` as it's in a non async function.

Thank you

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
