### PR TITLE
Restore behaviour in create_authorization_response call which previously accepted a OAuth2Request object as-is

### DIFF
--- a/authlib/oauth2/rfc6749/authorization_server.py
+++ b/authlib/oauth2/rfc6749/authorization_server.py
@@ -246,7 +246,9 @@ class AuthorizationServer(object):
             it is None.
         :returns: Response
         """
-        request = self.create_oauth2_request(request)
+        if not isinstance(request, OAuth2Request):
+            request = self.create_oauth2_request(request)
+
         try:
             grant = self.get_authorization_grant(request)
         except UnsupportedResponseTypeError as error:


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No - rather, fixes one. Explaination [here](https://github.com/lepture/authlib/commit/c060dab824f14929d33a567880042b026ed11b1b#r119835558)

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
