### PR TITLE
 use {posargs} tox parameter to customize pytest runs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ setenv =
     django: TESTPATH=tests/django
     django: DJANGO_SETTINGS_MODULE=tests.django.settings
 commands =
-    coverage run --source=authlib -p -m pytest {env:TESTPATH}
+    coverage run --source=authlib -p -m pytest {posargs: {env:TESTPATH}}
 
 [pytest]
 asyncio_mode = auto


### PR DESCRIPTION
This allows to run tox with parameters for pytest. For instance `tox -e py311-flask -- tests/flask/test_oauth2/test_oauth2_server.py` will only run that test file.

If no argument is passed, the default `TESTPATH` is still used.