### PR TITLE
use in-memory sqlite database with django tests

### DIFF
--- a/tests/clients/test_django/settings.py
+++ b/tests/clients/test_django/settings.py
@@ -3,7 +3,7 @@ SECRET_KEY = 'django-secret'
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
-        "NAME": "example.sqlite",
+        "NAME": ":memory:",
     }
 }
 

--- a/tests/django/settings.py
+++ b/tests/django/settings.py
@@ -3,7 +3,7 @@ SECRET_KEY = 'django-secret'
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
-        "NAME": "example.sqlite",
+        "NAME": ":memory:",
     }
 }
 


### PR DESCRIPTION
django tests use a inmemory sqlite database. This *should* be more performant but I doubt anyone will ever notice. However this avoids to create a `example.sqlite` file that git complains is untracked after running tox.