### PR TITLE
tests: move pytest-asyncio dependency in tests/requirements-base.txt

### DIFF
--- a/tests/requirements-base.txt
+++ b/tests/requirements-base.txt
@@ -1,3 +1,4 @@
 cryptography
 pytest
 coverage
+pytest-asyncio

--- a/tests/requirements-clients.txt
+++ b/tests/requirements-clients.txt
@@ -6,4 +6,3 @@ cachelib
 werkzeug
 flask
 django
-pytest-asyncio


### PR DESCRIPTION
This prevents this warnings on some tox test environments:

```
.tox/py311-django/lib/python3.11/site-packages/_pytest/config/__init__.py:1373
  /home/eloi/dev/authlib/.tox/py311-django/lib/python3.11/site-packages/_pytest/config/__init__.py:1373: PytestConfigWarning: Unknown config option: asyncio_mode

    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")
```

These warnings appears because this configuration is shared across all the tox environments:

https://github.com/lepture/authlib/blob/eaa51a8d65f21eff98ed0eb1b86b07801d68c98d/tox.ini#L27-L28