### PR TITLE
register several endpoints of a kind

### DIFF
--- a/authlib/common/errors.py
+++ b/authlib/common/errors.py
@@ -57,3 +57,7 @@ class AuthlibHTTPError(AuthlibBaseError):
         body = dict(self.get_body())
         headers = self.get_headers()
         return self.status_code, body, headers
+
+
+class ContinueIteration(AuthlibBaseError):
+    pass


### PR DESCRIPTION
I am currently tackling #427 and I realize it would be easier for me if one could register several endpoints of a kind. For instance one `JWTAccessTokenIntrospectionEndpoint` that would read the introspection data from the JWT access token, and a regular `IntrospectionEndpoint` for the other kind of tokens.

With this patch, if `JWTAccessTokenIntrospectionEndpoint` would meet a plain-text access token, it would raise a `ContinueIteration` exception and pass to the `IntrospectionEndpoint`. Same if the token_hint is a refresh token for instance (RFC9068 is only about access tokens).

This would also help for the revokation endpoint.

What do you think?
