### PR TITLE
Add remove_client method to base_client.registry.BaseOAuth

### DIFF
--- a/authlib/integrations/base_client/registry.py
+++ b/authlib/integrations/base_client/registry.py
@@ -86,6 +86,16 @@ class BaseOAuth:
         self._registry[name] = (overwrite, kwargs)
         return self.create_client(name)
 
+    def remove_client(self, name):
+        if name not in self._registry:
+            raise KeyError(f"Client {name} not found in registry.")
+
+        if name not in self._clients:
+            raise KeyError(f"Client {name} not found in clients.")
+        
+        del self._registry[name]
+        del self._clients[name]
+
     def generate_client_kwargs(self, name, overwrite, **kwargs):
         fetch_token = kwargs.pop('fetch_token', None)
         update_token = kwargs.pop('update_token', None)


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ x ] Feature

Feature to support removing a client from the `oauth` instance (see [this issue](https://github.com/lepture/authlib/issues/583)).

---

- [ x ] You consent that the copyright of your pull request source code belongs to Authlib's author.
