### PR TITLE
 Get werkzeug version using importlib

### DIFF
--- a/authlib/integrations/flask_oauth2/errors.py
+++ b/authlib/integrations/flask_oauth2/errors.py
@@ -1,7 +1,9 @@
+import importlib
+
 import werkzeug
 from werkzeug.exceptions import HTTPException
 
-_version = werkzeug.__version__.split('.')[0]
+_version = importlib.metadata.version('werkzeug').split('.')[0]
 
 if _version in ('0', '1'):
     class _HTTPException(HTTPException):


### PR DESCRIPTION
Resolves deprecation warning:
```
.venv/lib/python3.11/site-packages/authlib/integrations/flask_oauth2/errors.py:4: DeprecationWarning: The '__version__' attribute is deprecated and will be removed in Werkzeug 3.1. Use feature detection or 'importlib.metadata.version("werkzeug")' instead.
    _version = werkzeug.__version__.split('.')[0]
```

> DO NOT SEND ANY SECURITY FIX HERE. Please read "Security Reporting" section
> on README.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

(If no, please delete the above question and this text message.)

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
