### PR TITLE
Make sure 'code' returns None instead of crashing if key is missing.

### DIFF
--- a/authlib/integrations/flask_client/apps.py
+++ b/authlib/integrations/flask_client/apps.py
@@ -85,12 +85,12 @@ class FlaskOAuth2App(FlaskAppMixin, OAuth2Mixin, OpenIDMixin, BaseApp):
                 raise OAuthError(error=error, description=description)
 
             params = {
-                'code': request.args['code'],
+                'code': request.args.get('code'),
                 'state': request.args.get('state'),
             }
         else:
             params = {
-                'code': request.form['code'],
+                'code': request.form.get('code'),
                 'state': request.form.get('state'),
             }
 


### PR DESCRIPTION
> DO NOT SEND ANY SECURITY FIX HERE. Please read "Security Reporting" section
> on README.

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

---

- [X] You consent that the copyright of your pull request source code belongs to Authlib's author.

---

Instead of having the library users keeping track of which requests.args that are needed, change the behavior to not crash if variables requirements are not met. 

Example code before change:
```
authorize = Blueprint('authorize', __name__)

@authorize.route('/<client_name>')
def oauth(client_name):
    """ Verify oauth """
    args = request.args
    if None in (args.get("code"), args.get("state")):
        abort(500)
    client = _oauth.create_client(client_name)
    if not client:
        abort(404)
    token = client.authorize_access_token()
```

Example code after change:
Now the correct raise will occur which we can check for as expected:
```
from authlib.integrations.base_client.errors import MismatchingStateError
authorize = Blueprint('authorize', __name__)

@authorize.route('/<client_name>')
def oauth(client_name):
    """ Verify oauth """
    client = _oauth.create_client(client_name)
    if not client:
        abort(404)

    try:
        token = client.authorize_access_token()
    except MismatchingStateError:
        abort(500)
```