### PR TITLE
Fix encode_client_secret_basic to match RFC 6749

### DIFF
--- a/authlib/oauth2/auth.py
+++ b/authlib/oauth2/auth.py
@@ -1,4 +1,5 @@
 import base64
+from urllib.parse import quote
 from authlib.common.urls import add_params_to_qs, add_params_to_uri
 from authlib.common.encoding import to_bytes, to_native
 from .rfc6749 import OAuth2Token
@@ -6,7 +7,7 @@ from .rfc6750 import add_bearer_token
 
 
 def encode_client_secret_basic(client, method, uri, headers, body):
-    text = f'{client.client_id}:{client.client_secret}'
+    text = f'{quote(client.client_id)}:{quote(client.client_secret)}'
     auth = to_native(base64.b64encode(to_bytes(text, 'latin1')))
     headers['Authorization'] = f'Basic {auth}'
     return uri, headers, body


### PR DESCRIPTION
Added url encoding of client_id and client_secret in encode_client_secret_basic per RFC 6749:
https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1

This fixes the unsupported situation where there is a colon character in the client_id or in the client_secret.

> DO NOT SEND ANY SECURITY FIX HERE. Please read "Security Reporting" section
> on README.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix - fixes #595
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
