### PR TITLE
Fix error when RFC9068 JWS has no scope field

### DIFF
--- a/authlib/oauth2/rfc9068/token_validator.py
+++ b/authlib/oauth2/rfc9068/token_validator.py
@@ -140,7 +140,7 @@ class JWTBearerTokenValidator(BearerTokenValidator):
         # more considerations about the relationship between scope strings and resources
         # indicated by the 'aud' claim.
 
-        if self.scope_insufficient(token['scope'], scopes):
+        if self.scope_insufficient(token.get('scope', []), scopes):
             raise InsufficientScopeError()
 
         # Many authorization servers embed authorization attributes that go beyond the


### PR DESCRIPTION
The `scope` claim is optional in RFC9068. This PR fixes the current behaviour which is that it is mandatory by authlib.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
