### PR TITLE
Make token refresh more user friendly

### DIFF
--- a/authlib/oauth2/client.py
+++ b/authlib/oauth2/client.py
@@ -223,7 +223,7 @@ class OAuth2Client:
         self.token = token
         return token
 
-    def refresh_token(self, url, refresh_token=None, body='',
+    def refresh_token(self, url=None, refresh_token=None, body='',
                       auth=None, headers=None, **kwargs):
         """Fetch a new access token using a refresh token.
 
@@ -247,6 +247,9 @@ class OAuth2Client:
         if headers is None:
             headers = DEFAULT_HEADERS.copy()
 
+        if url is None:
+            url = self.metadata.get('token_endpoint')
+
         for hook in self.compliance_hook['refresh_token_request']:
             url, headers, body = hook(url, headers, body)
 
@@ -257,7 +260,9 @@ class OAuth2Client:
             url, refresh_token=refresh_token, body=body, headers=headers,
             auth=auth, **session_kwargs)
 
-    def ensure_active_token(self, token):
+    def ensure_active_token(self, token=None):
+        if token is None:
+            token = self.token
         if not token.is_expired():
             return True
         refresh_token = token.get('refresh_token')


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Other, please describe:

Make `client.refresh_token()` and `client.ensure_active_token()` work without needing to supply any parameters.

`client` may already have the necessary token endpoint or token, so caller should not be required to provide them.

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
