### PR TITLE
RFC7592: set default values for `grant_types` and `response_types` when updating client

### DIFF
--- a/authlib/oauth2/rfc7592/endpoint.py
+++ b/authlib/oauth2/rfc7592/endpoint.py
@@ -136,7 +136,10 @@ class ClientConfigurationEndpoint:
             response_types_supported = set(response_types_supported)
 
             def _validate_response_types(claims, value):
-                return response_types_supported.issuperset(set(value))
+                # If omitted, the default is that the client will use only the "code"
+                # response type.
+                response_types = set(value) if value else {"code"}
+                return response_types_supported.issuperset(response_types)
 
             options['response_types'] = {'validate': _validate_response_types}
 
@@ -144,7 +147,10 @@ class ClientConfigurationEndpoint:
             grant_types_supported = set(grant_types_supported)
 
             def _validate_grant_types(claims, value):
-                return grant_types_supported.issuperset(set(value))
+                # If omitted, the default behavior is that the client will use only
+                # the "authorization_code" Grant Type.
+                grant_types = set(value) if value else {"authorization_code"}
+                return grant_types_supported.issuperset(grant_types)
 
             options['grant_types'] = {'validate': _validate_grant_types}
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.

---

While implementing [RFC7592 endpoint](https://github.com/lepture/authlib/blob/master/authlib/oauth2/rfc7592/endpoint.py) in my code base, I noticed a crash could occur when updating the client if `grant_types` or `response_types` were not provided:

```
  File "/Users/fvoron/Development/polar/server/.venv/lib/python3.12/site-packages/authlib/oauth2/rfc7592/endpoint.py", line 147, in _validate_grant_types
    return grant_types_supported.issuperset(set(value))
                                            ^^^^^^^^^^
TypeError: 'NoneType' object is not iterable
```

In RFC7591 endpoint, there is a fail-safe fallback to avoid this:

https://github.com/lepture/authlib/blob/5ac468051098d544dd5bfad24f692ec1a6bc7ec1/authlib/oauth2/rfc7591/endpoint.py#L110-L114

https://github.com/lepture/authlib/blob/5ac468051098d544dd5bfad24f692ec1a6bc7ec1/authlib/oauth2/rfc7591/endpoint.py#L121-L125

This PR just backports this behavior to RFC7592. The effect is that, if not provided, `grant_types` and `response_types` will be set to the default value. From my understanding, this behavior is compliant with the [specification](https://datatracker.ietf.org/doc/html/rfc7592#section-2.2):

> Omitted fields MUST be treated as null or empty values by the server,
>  indicating the client's request to delete them from the client's
>  registration.  The authorization server MAY ignore any null or empty
>  value in the request just as any other value.
