### PR TITLE
fix: OIDC "login" prompt should be "login" even if user authenticated

### DIFF
--- a/authlib/oidc/core/grants/util.py
+++ b/authlib/oidc/core/grants/util.py
@@ -114,7 +114,7 @@ def create_response_mode_response(redirect_uri, params, response_mode):
 def _guess_prompt_value(end_user, prompts, redirect_uri, redirect_fragment):
     # http://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
 
-    if not end_user and 'login' in prompts:
+    if not end_user or 'login' in prompts:
         return 'login'
 
     if 'consent' in prompts:

--- a/tests/flask/test_oauth2/test_openid_code_grant.py
+++ b/tests/flask/test_oauth2/test_openid_code_grant.py
@@ -163,6 +163,10 @@ class OpenIDCodeTest(BaseTestCase):
         rv = self.client.get('/oauth/authorize?' + query)
         self.assertEqual(rv.data, b'login')
 
+        query = url_encode(params + [('user_id', '1'), ('prompt', 'login')])
+        rv = self.client.get('/oauth/authorize?' + query)
+        self.assertEqual(rv.data, b'login')
+
 
 class RSAOpenIDCodeTest(BaseTestCase):
     def config_app(self):


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.

---

OpenID Connect specification states the following about the `prompt=login` parameter:

> The Authorization Server SHOULD prompt the End-User for reauthentication. If it cannot reauthenticate the End-User, it MUST return an error, typically login_required.

Ref: https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest

In the current implementation, if `end_user` is present, the `login` prompt is ignored and set to `None`. We should instead keep this prompt so the end-developer can force a re-authentication of the user.
