### PR TITLE
rfc7636: validate code challenge format

### DIFF
--- a/authlib/oauth2/rfc7636/challenge.py
+++ b/authlib/oauth2/rfc7636/challenge.py
@@ -9,6 +9,7 @@ from ..rfc6749 import (
 
 
 CODE_VERIFIER_PATTERN = re.compile(r'^[a-zA-Z0-9\-._~]{43,128}$')
+CODE_CHALLENGE_PATTERN = re.compile(r'^[a-zA-Z0-9\-._~]{43,128}$')
 
 
 def create_s256_code_challenge(code_verifier):
@@ -75,6 +76,9 @@ class CodeChallenge:
 
         if not challenge:
             raise InvalidRequestError('Missing "code_challenge"')
+
+        if not CODE_CHALLENGE_PATTERN.match(challenge):
+            raise InvalidRequestError('Invalid "code_challenge"')
 
         if method and method not in self.SUPPORTED_CODE_CHALLENGE_METHOD:
             raise InvalidRequestError('Unsupported "code_challenge_method"')

--- a/tests/flask/test_oauth2/test_code_challenge.py
+++ b/tests/flask/test_oauth2/test_code_challenge.py
@@ -65,18 +65,23 @@ class CodeChallengeTest(TestCase):
 
     def test_has_code_challenge(self):
         self.prepare_data()
-        rv = self.client.get(self.authorize_url + '&code_challenge=abc')
+        rv = self.client.get(self.authorize_url + '&code_challenge=Zhs2POMonIVVHZteWfoU7cSXQSm0YjghikFGJSDI2_s')
         self.assertEqual(rv.data, b'ok')
+
+    def test_invalid_code_challenge(self):
+        self.prepare_data()
+        rv = self.client.get(self.authorize_url + '&code_challenge=abc&code_challenge_method=plain')
+        self.assertIn(b'Invalid', rv.data)
 
     def test_invalid_code_challenge_method(self):
         self.prepare_data()
-        suffix = '&code_challenge=abc&code_challenge_method=invalid'
+        suffix = '&code_challenge=Zhs2POMonIVVHZteWfoU7cSXQSm0YjghikFGJSDI2_s&code_challenge_method=invalid'
         rv = self.client.get(self.authorize_url + suffix)
         self.assertIn(b'Unsupported', rv.data)
 
     def test_supported_code_challenge_method(self):
         self.prepare_data()
-        suffix = '&code_challenge=abc&code_challenge_method=plain'
+        suffix = '&code_challenge=Zhs2POMonIVVHZteWfoU7cSXQSm0YjghikFGJSDI2_s&code_challenge_method=plain'
         rv = self.client.get(self.authorize_url + suffix)
         self.assertEqual(rv.data, b'ok')
 
@@ -101,7 +106,7 @@ class CodeChallengeTest(TestCase):
 
     def test_missing_code_verifier(self):
         self.prepare_data()
-        url = self.authorize_url + '&code_challenge=foo'
+        url = self.authorize_url + '&code_challenge=Zhs2POMonIVVHZteWfoU7cSXQSm0YjghikFGJSDI2_s'
         rv = self.client.post(url, data={'user_id': '1'})
         self.assertIn('code=', rv.location)
 
@@ -117,7 +122,7 @@ class CodeChallengeTest(TestCase):
 
     def test_trusted_client_missing_code_verifier(self):
         self.prepare_data('client_secret_basic')
-        url = self.authorize_url + '&code_challenge=foo'
+        url = self.authorize_url + '&code_challenge=Zhs2POMonIVVHZteWfoU7cSXQSm0YjghikFGJSDI2_s'
         rv = self.client.post(url, data={'user_id': '1'})
         self.assertIn('code=', rv.location)
 
@@ -133,7 +138,7 @@ class CodeChallengeTest(TestCase):
 
     def test_plain_code_challenge_invalid(self):
         self.prepare_data()
-        url = self.authorize_url + '&code_challenge=foo'
+        url = self.authorize_url + '&code_challenge=Zhs2POMonIVVHZteWfoU7cSXQSm0YjghikFGJSDI2_s'
         rv = self.client.post(url, data={'user_id': '1'})
         self.assertIn('code=', rv.location)
 
@@ -150,7 +155,7 @@ class CodeChallengeTest(TestCase):
 
     def test_plain_code_challenge_failed(self):
         self.prepare_data()
-        url = self.authorize_url + '&code_challenge=foo'
+        url = self.authorize_url + '&code_challenge=Zhs2POMonIVVHZteWfoU7cSXQSm0YjghikFGJSDI2_s'
         rv = self.client.post(url, data={'user_id': '1'})
         self.assertIn('code=', rv.location)
 
@@ -206,7 +211,7 @@ class CodeChallengeTest(TestCase):
 
     def test_not_implemented_code_challenge_method(self):
         self.prepare_data()
-        url = self.authorize_url + '&code_challenge=foo'
+        url = self.authorize_url + '&code_challenge=Zhs2POMonIVVHZteWfoU7cSXQSm0YjghikFGJSDI2_s'
         url += '&code_challenge_method=S128'
 
         rv = self.client.post(url, data={'user_id': '1'})


### PR DESCRIPTION
[Section 4.2 of RFC 7636](https://datatracker.ietf.org/doc/html/rfc7636#section-4.2) mentions the ABNF form to which the code challenge should adhere. authlib currently accepts any string in code_challenge without validating if it matches the format specified in the RFC. Fix the same and also update relevant tests.

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

---

- [X] You consent that the copyright of your pull request source code belongs to Authlib's author.
