### PR TITLE
Fix authlib.oauth2.rfc9068.JWTIntrospectionEndpoint documentation mistakes

### DIFF
--- a/authlib/oauth2/rfc9068/introspection.py
+++ b/authlib/oauth2/rfc9068/introspection.py
@@ -20,7 +20,7 @@ class JWTIntrospectionEndpoint(IntrospectionEndpoint):
 
     ::
 
-        class MyJWTAccessTokenIntrospectionEndpoint(JWTRevocationEndpoint):
+        class MyJWTAccessTokenIntrospectionEndpoint(JWTIntrospectionEndpoint):
             def get_jwks(self):
                 ...
 
@@ -32,7 +32,7 @@ class JWTIntrospectionEndpoint(IntrospectionEndpoint):
                 issuer="https://authorization-server.example.org",
             )
         )
-        authorization_server.register_endpoint(MyRefreshTokenIntrospectionEndpoint)
+        authorization_server.register_endpoint(MyJWTAccessTokenIntrospectionEndpoint)
 
     '''
 

--- a/authlib/oauth2/rfc9068/introspection.py
+++ b/authlib/oauth2/rfc9068/introspection.py
@@ -32,7 +32,6 @@ class JWTIntrospectionEndpoint(IntrospectionEndpoint):
                 issuer="https://authorization-server.example.org",
             )
         )
-        authorization_server.register_endpoint(MyJWTAccessTokenIntrospectionEndpoint)
 
     '''
 


### PR DESCRIPTION
A small fix to the documentation of `authlib.oauth2.rfc9068.JWTIntrospectionEndpoint`

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
