### PR TITLE
rfc6749: ensure request parameters are not included more than once in authorization endpoint

### DIFF
--- a/authlib/integrations/django_oauth2/requests.py
+++ b/authlib/integrations/django_oauth2/requests.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 from django.http import HttpRequest
 from django.utils.functional import cached_property
 from authlib.common.encoding import json_loads
@@ -23,6 +25,15 @@ class DjangoOAuth2Request(OAuth2Request):
         data.update(self._request.GET.dict())
         data.update(self._request.POST.dict())
         return data
+
+    @cached_property
+    def datalist(self):
+        values = defaultdict(list)
+        for k in self.args:
+            values[k].extend(self.args.getlist(k))
+        for k in self.form:
+            values[k].extend(self.form.getlist(k))
+        return values
 
 
 class DjangoJsonRequest(JsonRequest):

--- a/authlib/integrations/flask_oauth2/requests.py
+++ b/authlib/integrations/flask_oauth2/requests.py
@@ -1,3 +1,6 @@
+from collections import defaultdict
+from functools import cached_property
+
 from flask.wrappers import Request
 from authlib.oauth2.rfc6749 import OAuth2Request, JsonRequest
 
@@ -18,6 +21,13 @@ class FlaskOAuth2Request(OAuth2Request):
     @property
     def data(self):
         return self._request.values
+
+    @cached_property
+    def datalist(self):
+        values = defaultdict(list)
+        for k in self.data:
+            values[k].extend(self.data.getlist(k))
+        return values
 
 
 class FlaskJsonRequest(JsonRequest):

--- a/authlib/oauth2/rfc6749/authorization_server.py
+++ b/authlib/oauth2/rfc6749/authorization_server.py
@@ -214,6 +214,7 @@ class AuthorizationServer:
         request.user = end_user
 
         grant = self.get_authorization_grant(request)
+        grant.validate_no_multiple_request_parameter(request)
         grant.validate_consent_request()
         return grant
 

--- a/authlib/oauth2/rfc6749/grants/base.py
+++ b/authlib/oauth2/rfc6749/grants/base.py
@@ -147,7 +147,7 @@ class AuthorizationEndpointMixin:
         datalist = request.datalist
         parameters = ["response_type", "client_id", "redirect_uri", "scope", "state"]
         for param in parameters:
-            if len(datalist[param]) > 1:
+            if len(datalist.get(param, [])) > 1:
                 raise InvalidRequestError(f'Multiple "{param}" in request.', state=request.state)
 
     def validate_consent_request(self):

--- a/authlib/oauth2/rfc6749/grants/base.py
+++ b/authlib/oauth2/rfc6749/grants/base.py
@@ -1,4 +1,5 @@
 from authlib.consts import default_json_headers
+from authlib.common.urls import urlparse
 from ..requests import OAuth2Request
 from ..errors import InvalidRequestError
 
@@ -135,6 +136,19 @@ class AuthorizationEndpointMixin:
                     'Missing "redirect_uri" in request.',
                     state=request.state)
             return redirect_uri
+
+    @staticmethod
+    def validate_no_multiple_request_parameter(request: OAuth2Request):
+        """For the Authorization Endpoint, request and response parameters MUST NOT be included
+        more than once. Per `Section 3.1`_.
+
+        .. _`Section 3.1`: https://tools.ietf.org/html/rfc6749#section-3.1
+        """
+        datalist = request.datalist
+        parameters = ["response_type", "client_id", "redirect_uri", "scope", "state"]
+        for param in parameters:
+            if len(datalist[param]) > 1:
+                raise InvalidRequestError(f'Multiple "{param}" in request.', state=request.state)
 
     def validate_consent_request(self):
         redirect_uri = self.validate_authorization_request()

--- a/authlib/oauth2/rfc6749/requests.py
+++ b/authlib/oauth2/rfc6749/requests.py
@@ -1,3 +1,6 @@
+from collections import defaultdict
+from typing import DefaultDict
+
 from authlib.common.encoding import json_loads
 from authlib.common.urls import urlparse, url_decode
 from .errors import InsecureTransportError
@@ -20,10 +23,13 @@ class OAuth2Request:
         self.refresh_token = None
         self.credential = None
 
+        self._parsed_query = None
+
     @property
     def args(self):
-        query = urlparse.urlparse(self.uri).query
-        return dict(url_decode(query))
+        if self._parsed_query is None:
+            self._parsed_query = url_decode(urlparse.urlparse(self.uri).query)
+        return dict(self._parsed_query)
 
     @property
     def form(self):
@@ -35,6 +41,19 @@ class OAuth2Request:
         data.update(self.args)
         data.update(self.form)
         return data
+
+    @property
+    def datalist(self) -> DefaultDict[str, list]:
+        """ Return all the data in query parameters and the body of the request as a dictionary with all the values
+        in lists. """
+        if self._parsed_query is None:
+            self._parsed_query = url_decode(urlparse.urlparse(self.uri).query)
+        values = defaultdict(list)
+        for k, v in self._parsed_query:
+            values[k].append(v)
+        for k, v in self.form.items():
+            values[k].append(v)
+        return values
 
     @property
     def client_id(self) -> str:

--- a/authlib/oauth2/rfc7636/challenge.py
+++ b/authlib/oauth2/rfc7636/challenge.py
@@ -77,7 +77,7 @@ class CodeChallenge:
         if not challenge:
             raise InvalidRequestError('Missing "code_challenge"')
 
-        if len(request.datalist.get('code_challenge')) > 1:
+        if len(request.datalist.get('code_challenge', [])) > 1:
             raise InvalidRequestError('Multiple "code_challenge" in request.')
 
         if not CODE_CHALLENGE_PATTERN.match(challenge):
@@ -86,7 +86,7 @@ class CodeChallenge:
         if method and method not in self.SUPPORTED_CODE_CHALLENGE_METHOD:
             raise InvalidRequestError('Unsupported "code_challenge_method"')
 
-        if len(request.datalist.get('code_challenge_method')) > 1:
+        if len(request.datalist.get('code_challenge_method', [])) > 1:
             raise InvalidRequestError('Multiple "code_challenge_method" in request.')
 
     def validate_code_verifier(self, grant):

--- a/authlib/oauth2/rfc7636/challenge.py
+++ b/authlib/oauth2/rfc7636/challenge.py
@@ -77,11 +77,17 @@ class CodeChallenge:
         if not challenge:
             raise InvalidRequestError('Missing "code_challenge"')
 
+        if len(request.datalist.get('code_challenge')) > 1:
+            raise InvalidRequestError('Multiple "code_challenge" in request.')
+
         if not CODE_CHALLENGE_PATTERN.match(challenge):
             raise InvalidRequestError('Invalid "code_challenge"')
 
         if method and method not in self.SUPPORTED_CODE_CHALLENGE_METHOD:
             raise InvalidRequestError('Unsupported "code_challenge_method"')
+
+        if len(request.datalist.get('code_challenge_method')) > 1:
+            raise InvalidRequestError('Multiple "code_challenge_method" in request.')
 
     def validate_code_verifier(self, grant):
         request: OAuth2Request = grant.request

--- a/tests/django/test_oauth2/test_authorization_code_grant.py
+++ b/tests/django/test_oauth2/test_authorization_code_grant.py
@@ -68,6 +68,14 @@ class AuthorizationCodeTest(TestCase):
             request
         )
 
+        url = '/authorize?response_type=code&client_id=client&scope=profile&state=bar&redirect_uri=https%3A%2F%2Fa.b&response_type=code'
+        request = self.factory.get(url)
+        self.assertRaises(
+            errors.InvalidRequestError,
+            server.get_consent_grant,
+            request
+        )
+
     def test_get_consent_grant_redirect_uri(self):
         server = self.create_server()
         self.prepare_data()

--- a/tests/flask/test_oauth2/test_authorization_code_grant.py
+++ b/tests/flask/test_oauth2/test_authorization_code_grant.py
@@ -210,6 +210,13 @@ class AuthorizationCodeTest(TestCase):
         self.assertIn('access_token', resp)
         self.assertIn('refresh_token', resp)
 
+    def test_invalid_multiple_request_parameters(self):
+        self.prepare_data()
+        url = self.authorize_url + '&scope=profile&state=bar&redirect_uri=https%3A%2F%2Fa.b&response_type=code'
+        rv = self.client.get(url)
+        self.assertIn(b'invalid_request', rv.data)
+        self.assertIn(b'Multiple+%22response_type%22+in+request.', rv.data)
+
     def test_client_secret_post(self):
         self.app.config.update({'OAUTH2_REFRESH_TOKEN_GENERATOR': True})
         self.prepare_data(


### PR DESCRIPTION
[Section 3.1 of the RFC6749](https://datatracker.ietf.org/doc/html/rfc6749#section-3.1) says "Request and response parameters MUST NOT be included more than once."

Add a method to the OAuth2Request object to obtain all the values for the keys in form + args data as a list. This helps detects repetition of request parameters. Also, add a django and flask test for the same.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

Possible breaking change for applications because clients that were repeating parameters in the request will now get an InvalidRequest error instead of successful authorization.

I don't see a reason why any client would do it intentionally but its enough of a concern, maybe we can add a flag or config to AuthorizationEndpointMixin to conditionally enable the check.

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
