### PR TITLE
rfc7009: return error if client validation fails

### DIFF
--- a/authlib/oauth2/rfc7009/revocation.py
+++ b/authlib/oauth2/rfc7009/revocation.py
@@ -1,5 +1,5 @@
 from authlib.consts import default_json_headers
-from ..rfc6749 import TokenEndpoint
+from ..rfc6749 import TokenEndpoint, InvalidGrantError
 from ..rfc6749 import (
     InvalidRequestError,
     UnsupportedTokenTypeError,
@@ -29,8 +29,9 @@ class RevocationEndpoint(TokenEndpoint):
         """
         self.check_params(request, client)
         token = self.query_token(request.form['token'], request.form.get('token_type_hint'))
-        if token and token.check_client(client):
-            return token
+        if token and not token.check_client(client):
+            raise InvalidGrantError()
+        return token
 
     def check_params(self, request, client):
         if 'token' not in request.form:


### PR DESCRIPTION
[Section 2 of RFC 7009](https://datatracker.ietf.org/doc/html/rfc7009#section-2) says:

"The authorization server first validates the client credentials (in
 case of a confidential client) and then verifies whether the token
 was issued to the client making the revocation request.  If this
 validation fails, the request is refused and the client is informed
 of the error by the authorization server as described below."

Accordingly, update the code to return an invalid_grant error if the token being revoked does not belong to client credentials supplied.

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

---

- [X] You consent that the copyright of your pull request source code belongs to Authlib's author.
