### PR TITLE
OAuth2Request should access `grant_type` through `data`

### DIFF
--- a/authlib/oauth2/rfc6749/requests.py
+++ b/authlib/oauth2/rfc6749/requests.py
@@ -76,7 +76,7 @@ class OAuth2Request:
 
     @property
     def grant_type(self) -> str:
-        return self.form.get('grant_type')
+        return self.data.get('grant_type')
 
     @property
     def redirect_uri(self):


### PR DESCRIPTION
The `grant_type` property of the `OAuth2Request` class should refer to the `data` collection (consistent with the other properties `response_type`, `client_id`, etc. and not through the base `form`. Without this change the following grant setting will not function:

```
TOKEN_ENDPOINT_HTTP_METHODS = ["GET"]
```

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No


---

- [X] You consent that the copyright of your pull request source code belongs to Authlib's author.
