### PR TITLE
Fix: use unique variable name when clearing old state data

### DIFF
--- a/authlib/integrations/starlette_client/integration.py
+++ b/authlib/integrations/starlette_client/integration.py
@@ -40,9 +40,9 @@ class StarletteIntegration(FrameworkIntegration):
             await self.cache.set(key, json.dumps({'data': data}), self.expires_in)
         elif session is not None:
             # clear old state data to avoid session size growing
-            for key in list(session.keys()):
-                if key.startswith(key_prefix):
-                    session.pop(key)
+            for old_key in list(session.keys()):
+                if old_key.startswith(key_prefix):
+                    session.pop(old_key)
             now = time.time()
             session[key] = {'data': data, 'exp': now + self.expires_in}
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.

---

Fixes issue where state data for OAuth could be set on an incorrect session key due to overwriting the key value when removing old session state data.
