### PR TITLE
OAuth2Client: use correct auth method for token introspection

### DIFF
--- a/authlib/oauth2/client.py
+++ b/authlib/oauth2/client.py
@@ -299,6 +299,8 @@ class OAuth2Client:
 
         .. _`RFC7009`: https://tools.ietf.org/html/rfc7009
         """
+        if auth is None:
+            auth = self.client_auth(self.revocation_endpoint_auth_method)
         return self._handle_token_hint(
             'revoke_token_request', url,
             token=token, token_type_hint=token_type_hint,
@@ -320,6 +322,8 @@ class OAuth2Client:
 
         .. _`RFC7662`: https://tools.ietf.org/html/rfc7662
         """
+        if auth is None:
+            auth = self.client_auth(self.token_endpoint_auth_method)
         return self._handle_token_hint(
             'introspect_token_request', url,
             token=token, token_type_hint=token_type_hint,


### PR DESCRIPTION
When token introspection was introduced in 6f5d19a, using the code that previously only handled token revocation, the new `_handle_token_hint` method that does the work for both `introspect_token` and `revoke_token` kept using
`self.revocation_endpoint_auth_method` unconditionally if no `auth` was passed in with the introspect or revoke request. This seems to be wrong, introspecting a token should use the `token_endpoint_auth_method`.

This leaves the fallback to `revocation_endpoint_auth_method` in `_handle_token_hint` because adjusting its signature to make `auth` compulsory would be awkward, but it's not expected ever to be used.

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix

**Does this PR introduce a breaking change?** (check one)

- [X] No

---

- [ ] You consent that the copyright of your pull request source code belongs to Authlib's author.
