### PR TITLE
update upload-artifact and download-artifact GHA actions

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -30,7 +30,7 @@ jobs:
     - name: build dist
       run: python -m build
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: artifacts
         path: dist/*
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: artifacts
         path: dist


### PR DESCRIPTION
v3 will soon be deprecated

![Capture d’écran du 2024-09-04 09-04-05](https://github.com/user-attachments/assets/c8b3221e-8f2b-4d98-8d3a-2f3bf577a598)
