### PR TITLE
Introducing Authlib Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 <a href="https://pypi.org/project/Authlib/"><img src="https://badgen.net/pypi/v/authlib" alt="PyPI Version"></a>
 <a href="https://codeclimate.com/github/lepture/authlib/maintainability"><img src="https://badgen.net/codeclimate/maintainability/lepture/authlib?icon=codeclimate" alt="Maintainability" /></a>
 <a href="https://twitter.com/intent/follow?screen_name=authlib"><img src="https://img.shields.io/twitter/follow/authlib.svg?maxAge=3600&style=social&logo=twitter&label=Follow" alt="Follow Twitter"></a>
+<a href="https://gurubase.io/g/authlib"><img src="https://img.shields.io/badge/Gurubase-Ask%20Authlib%20Guru-006BFF" alt="Gurubase"></a>
 
 The ultimate Python library in building OAuth and OpenID Connect servers.
 JWS, JWK, JWA, JWT are included.


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Authlib Guru](https://gurubase.io/g/authlib) to Gurubase. Authlib Guru uses the data from this repo and data from the [docs](https://docs.authlib.org/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Authlib Guru", which highlights that Authlib now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Authlib Guru in Gurubase, just let me know that's totally fine.
