### PR TITLE
Updated notes on using a ``cache`` instance when initializing ``OAuth``.

### DIFF
--- a/docs/client/flask.rst
+++ b/docs/client/flask.rst
@@ -98,9 +98,9 @@ system. When initializing ``OAuth``, you can pass an ``cache`` instance::
 
 A ``cache`` instance MUST have methods:
 
+- ``.delete(key)``
 - ``.get(key)``
 - ``.set(key, value, expires=None)``
-- ``.delete(key)``
 
 An example of a ``cache`` instance can be:
 
@@ -113,16 +113,14 @@ An example of a ``cache`` instance can be:
         def __init__(self, app: Flask) -> None:
             """Initialize the AuthCache."""
             self.app = app
-    
-        def set(self, key: str, value: str, expires: int | None = None) -> None:
+
+        def delete(self, key: str) -> None:
             """
-            Set a value in the cache with optional expiration.
+            Delete a cache entry.
     
             :param key: Unique identifier for the cache entry.
-            :param value: Value to be stored.
-            :param expires: Expiration time in seconds. Defaults to None (no expiration).
             """
-    
+
         def get(self, key: str) -> str | None:
             """
             Retrieve a value from the cache.
@@ -130,12 +128,14 @@ An example of a ``cache`` instance can be:
             :param key: Unique identifier for the cache entry.
             :return: Retrieved value or None if not found or expired.
             """
-    
-        def delete(self, key: str) -> None:
+
+        def set(self, key: str, value: str, expires: int | None = None) -> None:
             """
-            Delete a cache entry.
+            Set a value in the cache with optional expiration.
     
             :param key: Unique identifier for the cache entry.
+            :param value: Value to be stored.
+            :param expires: Expiration time in seconds. Defaults to None (no expiration).
             """
 
 

--- a/docs/client/flask.rst
+++ b/docs/client/flask.rst
@@ -100,6 +100,43 @@ A ``cache`` instance MUST have methods:
 
 - ``.get(key)``
 - ``.set(key, value, expires=None)``
+- ``.delete(key)``
+
+An example of a ``cache`` instance can be:
+
+.. code-block:: python
+
+    from flask import Flask
+
+    class OAuthCache:
+
+        def __init__(self, app: Flask) -> None:
+            """Initialize the AuthCache."""
+            self.app = app
+    
+        def set(self, key: str, value: str, expires: int | None = None) -> None:
+            """
+            Set a value in the cache with optional expiration.
+    
+            :param key: Unique identifier for the cache entry.
+            :param value: Value to be stored.
+            :param expires: Expiration time in seconds. Defaults to None (no expiration).
+            """
+    
+        def get(self, key: str) -> str | None:
+            """
+            Retrieve a value from the cache.
+    
+            :param key: Unique identifier for the cache entry.
+            :return: Retrieved value or None if not found or expired.
+            """
+    
+        def delete(self, key: str) -> None:
+            """
+            Delete a cache entry.
+    
+            :param key: Unique identifier for the cache entry.
+            """
 
 
 Routes for Authorization


### PR DESCRIPTION
> DO NOT SEND ANY SECURITY FIX HERE. Please read the "Security Reporting" section
> on README.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Other, please describe: Updated Flask OAuth Client documentation.

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.


The Flask OAuth Client documentation excludes important information about creating a `cache` instance for `OAuth` initialization.

Under FlaskClient `framework_integration.py` source code, 

```python
# File: authlib/integrations/base_client/framework_integration.py

def clear_state_data(self, session, state):
        key = f'_state_{self.name}_{state}'
        if self.cache:
            self.cache.delete(key)   # Calls the delete method on the cache object
        else:
            ...
```

You are required to have a `delete` method for the `cache` object else you get an `AttributeError` like this `AttributeError("'Cache' object has no attribute 'delete'")`.

This PR updates the documentation to inform users about the need to have a `delete` method as part of their `cache` instance.