### PR TITLE
Support httpx 0.28

### DIFF
--- a/authlib/integrations/httpx_client/assertion_client.py
+++ b/authlib/integrations/httpx_client/assertion_client.py
@@ -22,6 +22,11 @@ class AsyncAssertionClient(_AssertionClient, httpx.AsyncClient):
                  claims=None, token_placement='header', scope=None, **kwargs):
 
         client_kwargs = extract_client_kwargs(kwargs)
+        # app keyword was dropped!
+        app_value = client_kwargs.pop('app', None)
+        if app_value is not None:
+            client_kwargs['transport'] = httpx.ASGITransport(app=app_value)
+
         httpx.AsyncClient.__init__(self, **client_kwargs)
 
         _AssertionClient.__init__(
@@ -61,6 +66,11 @@ class AssertionClient(_AssertionClient, httpx.Client):
                  claims=None, token_placement='header', scope=None, **kwargs):
 
         client_kwargs = extract_client_kwargs(kwargs)
+        # app keyword was dropped!
+        app_value = client_kwargs.pop('app', None)
+        if app_value is not None:
+            client_kwargs['transport'] = httpx.WSGITransport(app=app_value)
+
         httpx.Client.__init__(self, **client_kwargs)
 
         _AssertionClient.__init__(

--- a/authlib/integrations/httpx_client/oauth1_client.py
+++ b/authlib/integrations/httpx_client/oauth1_client.py
@@ -34,6 +34,11 @@ class AsyncOAuth1Client(_OAuth1Client, httpx.AsyncClient):
                  force_include_body=False, **kwargs):
 
         _client_kwargs = extract_client_kwargs(kwargs)
+        # app keyword was dropped!
+        app_value = _client_kwargs.pop('app', None)
+        if app_value is not None:
+            _client_kwargs['transport'] = httpx.ASGITransport(app=app_value)
+
         httpx.AsyncClient.__init__(self, **_client_kwargs)
 
         _OAuth1Client.__init__(
@@ -87,6 +92,11 @@ class OAuth1Client(_OAuth1Client, httpx.Client):
                  force_include_body=False, **kwargs):
 
         _client_kwargs = extract_client_kwargs(kwargs)
+        # app keyword was dropped!
+        app_value = _client_kwargs.pop('app', None)
+        if app_value is not None:
+            _client_kwargs['transport'] = httpx.WSGITransport(app=app_value)
+
         httpx.Client.__init__(self, **_client_kwargs)
 
         _OAuth1Client.__init__(

--- a/authlib/integrations/httpx_client/oauth2_client.py
+++ b/authlib/integrations/httpx_client/oauth2_client.py
@@ -62,6 +62,11 @@ class AsyncOAuth2Client(_OAuth2Client, httpx.AsyncClient):
 
         # extract httpx.Client kwargs
         client_kwargs = self._extract_session_request_params(kwargs)
+        # app keyword was dropped!
+        app_value = client_kwargs.pop('app', None)
+        if app_value is not None:
+            client_kwargs['transport'] = httpx.ASGITransport(app=app_value)
+
         httpx.AsyncClient.__init__(self, **client_kwargs)
 
         # We use a Lock to synchronize coroutines to prevent
@@ -177,6 +182,11 @@ class OAuth2Client(_OAuth2Client, httpx.Client):
 
         # extract httpx.Client kwargs
         client_kwargs = self._extract_session_request_params(kwargs)
+        # app keyword was dropped!
+        app_value = client_kwargs.pop('app', None)
+        if app_value is not None:
+            client_kwargs['transport'] = httpx.WSGITransport(app=app_value)
+
         httpx.Client.__init__(self, **client_kwargs)
 
         _OAuth2Client.__init__(

--- a/tests/clients/test_httpx/test_async_oauth2_client.py
+++ b/tests/clients/test_httpx/test_async_oauth2_client.py
@@ -4,7 +4,7 @@ import pytest
 from unittest import mock
 from copy import deepcopy
 
-from httpx import AsyncClient
+from httpx import AsyncClient, ASGITransport
 
 from authlib.common.security import generate_token
 from authlib.common.urls import url_encode
@@ -96,7 +96,7 @@ async def test_add_token_to_streaming_request(assert_func, token_placement):
         token_placement="header",
         app=AsyncMockDispatch({'a': 'a'}, assert_func=assert_token_in_header)
     ),
-    AsyncClient(app=AsyncMockDispatch({'a': 'a'}))
+    AsyncClient(transport=ASGITransport(app=AsyncMockDispatch({'a': 'a'})))
 ])
 async def test_httpx_client_stream_match(client):
     async with client as client_entered:


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

(If no, please delete the above question and this text message.)

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.

** Description **

httpx 0.28.0 proceeded wit some pending deprecations, one of them was dropping the `app` keyword argument. In this PR I implemented a thin compatibility layer. Tests pass with this change.
