### PR TITLE
`kid` parameter for `generate_id_token`

### DIFF
--- a/authlib/oidc/core/grants/util.py
+++ b/authlib/oidc/core/grants/util.py
@@ -59,11 +59,15 @@ def validate_nonce(request, exists_nonce, required=False):
 
 def generate_id_token(
         token, user_info, key, iss, aud, alg='RS256', exp=3600,
-        nonce=None, auth_time=None, code=None):
+        nonce=None, auth_time=None, code=None, kid=None):
 
     now = int(time.time())
     if auth_time is None:
         auth_time = now
+
+    header = {'alg': alg}
+    if kid:
+        header["kid"] = kid
 
     payload = {
         'iss': iss,
@@ -83,7 +87,7 @@ def generate_id_token(
         payload['at_hash'] = to_native(create_half_hash(access_token, alg))
 
     payload.update(user_info)
-    return to_native(jwt.encode({'alg': alg}, payload, key))
+    return to_native(jwt.encode(header, payload, key))
 
 
 def create_response_mode_response(redirect_uri, params, response_mode):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,13 @@ Changelog
 
 Here you can see the full list of changes between each Authlib release.
 
+Version 1.x.x
+-------------
+
+**Unreleased**
+
+- ``generate_id_token`` can take a ``kid`` parmaeter. :pr:`702`
+
 Version 1.4.1
 -------------
 


### PR DESCRIPTION
While attempting to pass OIDC certification with [Canaille](https://canaille.readthedocs.io) I had a test failing due to a missing `kid` parameter in the id_token JWT header. The compliance test links to [this paragraph](https://openid.net/specs/openid-connect-core-1_0.html#rfc.section.10.1).

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
