### PR TITLE
OpenID Connect Dynamic Client Registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Generic, spec-compliant implementation to build clients and providers:
 - [OpenID Connect 1.0](https://docs.authlib.org/en/latest/specs/oidc.html)
   - [x] OpenID Connect Core 1.0
   - [x] OpenID Connect Discovery 1.0
+  - [x] OpenID Connect Dynamic Client Registration 1.0
 
 Connect third party OAuth providers with Authlib built-in client integrations:
 

--- a/authlib/jose/__init__.py
+++ b/authlib/jose/__init__.py
@@ -1,4 +1,4 @@
-"""authlib.jose.
+"""authlib.jose
 ~~~~~~~~~~~~
 
 JOSE implementation in Authlib. Tracking the status of JOSE specs at

--- a/authlib/oauth2/rfc7592/endpoint.py
+++ b/authlib/oauth2/rfc7592/endpoint.py
@@ -5,7 +5,6 @@ from ..rfc6749 import AccessDeniedError
 from ..rfc6749 import InvalidClientError
 from ..rfc6749 import InvalidRequestError
 from ..rfc6749 import UnauthorizedClientError
-from ..rfc6749 import scope_to_list
 from ..rfc7591 import InvalidClientMetadataError
 from ..rfc7591.claims import ClientMetadataClaims
 
@@ -13,11 +12,9 @@ from ..rfc7591.claims import ClientMetadataClaims
 class ClientConfigurationEndpoint:
     ENDPOINT_NAME = "client_configuration"
 
-    #: The claims validation class
-    claims_class = ClientMetadataClaims
-
-    def __init__(self, server):
+    def __init__(self, server=None, claims_classes=None):
         self.server = server
+        self.claims_classes = claims_classes or [ClientMetadataClaims]
 
     def __call__(self, request):
         return self.create_configuration_response(request)
@@ -108,62 +105,22 @@ class ClientConfigurationEndpoint:
 
     def extract_client_metadata(self, request):
         json_data = request.data.copy()
-        options = self.get_claims_options()
-        claims = self.claims_class(json_data, {}, options, self.get_server_metadata())
+        client_metadata = {}
+        server_metadata = self.get_server_metadata()
+        for claims_class in self.claims_classes:
+            options = (
+                claims_class.get_claims_options(server_metadata)
+                if server_metadata
+                else {}
+            )
+            claims = claims_class(json_data, {}, options, server_metadata)
+            try:
+                claims.validate()
+            except JoseError as error:
+                raise InvalidClientMetadataError(error.description) from error
 
-        try:
-            claims.validate()
-        except JoseError as error:
-            raise InvalidClientMetadataError(error.description) from error
-        return claims.get_registered_claims()
-
-    def get_claims_options(self):
-        metadata = self.get_server_metadata()
-        if not metadata:
-            return {}
-
-        scopes_supported = metadata.get("scopes_supported")
-        response_types_supported = metadata.get("response_types_supported")
-        grant_types_supported = metadata.get("grant_types_supported")
-        auth_methods_supported = metadata.get("token_endpoint_auth_methods_supported")
-        options = {}
-        if scopes_supported is not None:
-            scopes_supported = set(scopes_supported)
-
-            def _validate_scope(claims, value):
-                if not value:
-                    return True
-                scopes = set(scope_to_list(value))
-                return scopes_supported.issuperset(scopes)
-
-            options["scope"] = {"validate": _validate_scope}
-
-        if response_types_supported is not None:
-            response_types_supported = set(response_types_supported)
-
-            def _validate_response_types(claims, value):
-                # If omitted, the default is that the client will use only the "code"
-                # response type.
-                response_types = set(value) if value else {"code"}
-                return response_types_supported.issuperset(response_types)
-
-            options["response_types"] = {"validate": _validate_response_types}
-
-        if grant_types_supported is not None:
-            grant_types_supported = set(grant_types_supported)
-
-            def _validate_grant_types(claims, value):
-                # If omitted, the default behavior is that the client will use only
-                # the "authorization_code" Grant Type.
-                grant_types = set(value) if value else {"authorization_code"}
-                return grant_types_supported.issuperset(grant_types)
-
-            options["grant_types"] = {"validate": _validate_grant_types}
-
-        if auth_methods_supported is not None:
-            options["token_endpoint_auth_method"] = {"values": auth_methods_supported}
-
-        return options
+            client_metadata.update(**claims.get_registered_claims())
+        return client_metadata
 
     def introspect_client(self, client):
         return {**client.client_info, **client.client_metadata}

--- a/authlib/oidc/discovery/models.py
+++ b/authlib/oidc/discovery/models.py
@@ -14,12 +14,12 @@ class OpenIDProviderMetadata(AuthorizationServerMetadata):
         "response_modes_supported",
         "grant_types_supported",
         "token_endpoint_auth_methods_supported",
-        "token_endpoint_auth_signing_alg_values_supported",
         "service_documentation",
         "ui_locales_supported",
         "op_policy_uri",
         "op_tos_uri",
         # added by OpenID
+        "token_endpoint_auth_signing_alg_values_supported",
         "acr_values_supported",
         "subject_types_supported",
         "id_token_signing_alg_values_supported",

--- a/authlib/oidc/registration/__init__.py
+++ b/authlib/oidc/registration/__init__.py
@@ -1,0 +1,3 @@
+from .claims import ClientMetadataClaims
+
+__all__ = ["ClientMetadataClaims"]

--- a/authlib/oidc/registration/claims.py
+++ b/authlib/oidc/registration/claims.py
@@ -1,0 +1,353 @@
+from authlib.common.urls import is_valid_url
+from authlib.jose import BaseClaims
+from authlib.jose.errors import InvalidClaimError
+
+
+class ClientMetadataClaims(BaseClaims):
+    REGISTERED_CLAIMS = [
+        "token_endpoint_auth_signing_alg",
+        "application_type",
+        "sector_identifier_uri",
+        "subject_type",
+        "id_token_signed_response_alg",
+        "id_token_encrypted_response_alg",
+        "id_token_encrypted_response_enc",
+        "userinfo_signed_response_alg",
+        "userinfo_encrypted_response_alg",
+        "userinfo_encrypted_response_enc",
+        "default_max_age",
+        "require_auth_time",
+        "default_acr_values",
+        "initiate_login_uri",
+        "request_object_signing_alg",
+        "request_object_encryption_alg",
+        "request_object_encryption_enc",
+        "request_uris",
+    ]
+
+    def validate(self):
+        self._validate_essential_claims()
+        self.validate_token_endpoint_auth_signing_alg()
+        self.validate_application_type()
+        self.validate_sector_identifier_uri()
+        self.validate_subject_type()
+        self.validate_id_token_signed_response_alg()
+        self.validate_id_token_encrypted_response_alg()
+        self.validate_id_token_encrypted_response_enc()
+        self.validate_userinfo_signed_response_alg()
+        self.validate_userinfo_encrypted_response_alg()
+        self.validate_userinfo_encrypted_response_enc()
+        self.validate_default_max_age()
+        self.validate_require_auth_time()
+        self.validate_default_acr_values()
+        self.validate_initiate_login_uri()
+        self.validate_request_object_signing_alg()
+        self.validate_request_object_encryption_alg()
+        self.validate_request_object_encryption_enc()
+        self.validate_request_uris()
+
+    def _validate_uri(self, key):
+        uri = self.get(key)
+        uris = uri if isinstance(uri, list) else [uri]
+        for uri in uris:
+            if uri and not is_valid_url(uri):
+                raise InvalidClaimError(key)
+
+    @classmethod
+    def get_claims_options(self, metadata):
+        """Generate claims options validation from Authorization Server metadata."""
+        options = {}
+
+        if acr_values_supported := metadata.get("acr_values_supported"):
+
+            def _validate_default_acr_values(claims, value):
+                return not value or set(value).issubset(set(acr_values_supported))
+
+            options["default_acr_values"] = {"validate": _validate_default_acr_values}
+
+        values_mapping = {
+            "token_endpoint_auth_signing_alg_values_supported": "token_endpoint_auth_signing_alg",
+            "subject_types_supported": "subject_type",
+            "id_token_signing_alg_values_supported": "id_token_signed_response_alg",
+            "id_token_encryption_alg_values_supported": "id_token_encrypted_response_alg",
+            "id_token_encryption_enc_values_supported": "id_token_encrypted_response_enc",
+            "userinfo_signing_alg_values_supported": "userinfo_signed_response_alg",
+            "userinfo_encryption_alg_values_supported": "userinfo_encrypted_response_alg",
+            "userinfo_encryption_enc_values_supported": "userinfo_encrypted_response_enc",
+            "request_object_signing_alg_values_supported": "request_object_signing_alg",
+            "request_object_encryption_alg_values_supported": "request_object_encryption_alg",
+            "request_object_encryption_enc_values_supported": "request_object_encryption_enc",
+        }
+
+        def make_validator(metadata_claim_values):
+            def _validate(claims, value):
+                return not value or value in metadata_claim_values
+
+            return _validate
+
+        for metadata_claim_name, request_claim_name in values_mapping.items():
+            if metadata_claim_values := metadata.get(metadata_claim_name):
+                options[request_claim_name] = {
+                    "validate": make_validator(metadata_claim_values)
+                }
+
+        return options
+
+    def validate_token_endpoint_auth_signing_alg(self):
+        """JWS [JWS] alg algorithm [JWA] that MUST be used for signing the JWT [JWT]
+        used to authenticate the Client at the Token Endpoint for the private_key_jwt
+        and client_secret_jwt authentication methods.
+
+        All Token Requests using these authentication methods from this Client MUST be
+        rejected, if the JWT is not signed with this algorithm. Servers SHOULD support
+        RS256. The value none MUST NOT be used. The default, if omitted, is that any
+        algorithm supported by the OP and the RP MAY be used.
+        """
+        if self.get("token_endpoint_auth_signing_alg") == "none":
+            raise InvalidClaimError("token_endpoint_auth_signing_alg")
+
+        self._validate_claim_value("token_endpoint_auth_signing_alg")
+
+    def validate_application_type(self):
+        """Kind of the application.
+
+        The default, if omitted, is web. The defined values are native or web. Web
+        Clients using the OAuth Implicit Grant Type MUST only register URLs using the
+        https scheme as redirect_uris; they MUST NOT use localhost as the hostname.
+        Native Clients MUST only register redirect_uris using custom URI schemes or
+        loopback URLs using the http scheme; loopback URLs use localhost or the IP
+        loopback literals 127.0.0.1 or [::1] as the hostname. Authorization Servers MAY
+        place additional constraints on Native Clients. Authorization Servers MAY
+        reject Redirection URI values using the http scheme, other than the loopback
+        case for Native Clients. The Authorization Server MUST verify that all the
+        registered redirect_uris conform to these constraints. This prevents sharing a
+        Client ID across different types of Clients.
+        """
+        self.setdefault("application_type", "web")
+        if self.get("application_type") not in ("web", "native"):
+            raise InvalidClaimError("application_type")
+
+        self._validate_claim_value("application_type")
+
+    def validate_sector_identifier_uri(self):
+        """URL using the https scheme to be used in calculating Pseudonymous Identifiers
+        by the OP.
+
+        The URL references a file with a single JSON array of redirect_uri values.
+        Please see Section 5. Providers that use pairwise sub (subject) values SHOULD
+        utilize the sector_identifier_uri value provided in the Subject Identifier
+        calculation for pairwise identifiers.
+        """
+        self._validate_uri("sector_identifier_uri")
+
+    def validate_subject_type(self):
+        """subject_type requested for responses to this Client.
+
+        The subject_types_supported discovery parameter contains a list of the supported
+        subject_type values for the OP. Valid types include pairwise and public.
+        """
+        self._validate_claim_value("subject_type")
+
+    def validate_id_token_signed_response_alg(self):
+        """JWS alg algorithm [JWA] REQUIRED for signing the ID Token issued to this
+        Client.
+
+        The value none MUST NOT be used as the ID Token alg value unless the Client uses
+        only Response Types that return no ID Token from the Authorization Endpoint
+        (such as when only using the Authorization Code Flow). The default, if omitted,
+        is RS256. The public key for validating the signature is provided by retrieving
+        the JWK Set referenced by the jwks_uri element from OpenID Connect Discovery 1.0
+        [OpenID.Discovery].
+        """
+        if self.get("id_token_signed_response_alg") == "none":
+            raise InvalidClaimError("id_token_signed_response_alg")
+
+        self.setdefault("id_token_signed_response_alg", "RS256")
+        self._validate_claim_value("id_token_signed_response_alg")
+
+    def validate_id_token_encrypted_response_alg(self):
+        """JWE alg algorithm [JWA] REQUIRED for encrypting the ID Token issued to this
+        Client.
+
+        If this is requested, the response will be signed then encrypted, with the
+        result being a Nested JWT, as defined in [JWT]. The default, if omitted, is that
+        no encryption is performed.
+        """
+        self._validate_claim_value("id_token_encrypted_response_alg")
+
+    def validate_id_token_encrypted_response_enc(self):
+        """JWE enc algorithm [JWA] REQUIRED for encrypting the ID Token issued to this
+        Client.
+
+        If id_token_encrypted_response_alg is specified, the default
+        id_token_encrypted_response_enc value is A128CBC-HS256. When
+        id_token_encrypted_response_enc is included, id_token_encrypted_response_alg
+        MUST also be provided.
+        """
+        if self.get("id_token_encrypted_response_enc") and not self.get(
+            "id_token_encrypted_response_alg"
+        ):
+            raise InvalidClaimError("id_token_encrypted_response_enc")
+
+        if self.get("id_token_encrypted_response_alg"):
+            self.setdefault("id_token_encrypted_response_enc", "A128CBC-HS256")
+
+        self._validate_claim_value("id_token_encrypted_response_enc")
+
+    def validate_userinfo_signed_response_alg(self):
+        """JWS alg algorithm [JWA] REQUIRED for signing UserInfo Responses.
+
+        If this is specified, the response will be JWT [JWT] serialized, and signed
+        using JWS. The default, if omitted, is for the UserInfo Response to return the
+        Claims as a UTF-8 [RFC3629] encoded JSON object using the application/json
+        content-type.
+        """
+        self._validate_claim_value("userinfo_signed_response_alg")
+
+    def validate_userinfo_encrypted_response_alg(self):
+        """JWE [JWE] alg algorithm [JWA] REQUIRED for encrypting UserInfo Responses.
+
+        If both signing and encryption are requested, the response will be signed then
+        encrypted, with the result being a Nested JWT, as defined in [JWT]. The default,
+        if omitted, is that no encryption is performed.
+        """
+        self._validate_claim_value("userinfo_encrypted_response_alg")
+
+    def validate_userinfo_encrypted_response_enc(self):
+        """JWE enc algorithm [JWA] REQUIRED for encrypting UserInfo Responses.
+
+        If userinfo_encrypted_response_alg is specified, the default
+        userinfo_encrypted_response_enc value is A128CBC-HS256. When
+        userinfo_encrypted_response_enc is included, userinfo_encrypted_response_alg
+        MUST also be provided.
+        """
+        if self.get("userinfo_encrypted_response_enc") and not self.get(
+            "userinfo_encrypted_response_alg"
+        ):
+            raise InvalidClaimError("userinfo_encrypted_response_enc")
+
+        if self.get("userinfo_encrypted_response_alg"):
+            self.setdefault("userinfo_encrypted_response_enc", "A128CBC-HS256")
+
+        self._validate_claim_value("userinfo_encrypted_response_enc")
+
+    def validate_default_max_age(self):
+        """Default Maximum Authentication Age.
+
+        Specifies that the End-User MUST be actively authenticated if the End-User was
+        authenticated longer ago than the specified number of seconds. The max_age
+        request parameter overrides this default value. If omitted, no default Maximum
+        Authentication Age is specified.
+        """
+        if self.get("default_max_age") is not None and not isinstance(
+            self["default_max_age"], (int, float)
+        ):
+            raise InvalidClaimError("default_max_age")
+
+        self._validate_claim_value("default_max_age")
+
+    def validate_require_auth_time(self):
+        """Boolean value specifying whether the auth_time Claim in the ID Token is
+        REQUIRED.
+
+        It is REQUIRED when the value is true. (If this is false, the auth_time Claim
+        can still be dynamically requested as an individual Claim for the ID Token using
+        the claims request parameter described in Section 5.5.1 of OpenID Connect Core
+        1.0 [OpenID.Core].) If omitted, the default value is false.
+        """
+        self.setdefault("require_auth_time", False)
+        if self.get("require_auth_time") is not None and not isinstance(
+            self["require_auth_time"], bool
+        ):
+            raise InvalidClaimError("require_auth_time")
+
+        self._validate_claim_value("require_auth_time")
+
+    def validate_default_acr_values(self):
+        """Default requested Authentication Context Class Reference values.
+
+        Array of strings that specifies the default acr values that the OP is being
+        requested to use for processing requests from this Client, with the values
+        appearing in order of preference. The Authentication Context Class satisfied by
+        the authentication performed is returned as the acr Claim Value in the issued ID
+        Token. The acr Claim is requested as a Voluntary Claim by this parameter. The
+        acr_values_supported discovery element contains a list of the supported acr
+        values supported by the OP. Values specified in the acr_values request parameter
+        or an individual acr Claim request override these default values.
+        """
+        self._validate_claim_value("default_acr_values")
+
+    def validate_initiate_login_uri(self):
+        """RI using the https scheme that a third party can use to initiate a login by
+        the RP, as specified in Section 4 of OpenID Connect Core 1.0 [OpenID.Core].
+
+        The URI MUST accept requests via both GET and POST. The Client MUST understand
+        the login_hint and iss parameters and SHOULD support the target_link_uri
+        parameter.
+        """
+        self._validate_uri("initiate_login_uri")
+
+    def validate_request_object_signing_alg(self):
+        """JWS [JWS] alg algorithm [JWA] that MUST be used for signing Request Objects
+        sent to the OP.
+
+        All Request Objects from this Client MUST be rejected, if not signed with this
+        algorithm. Request Objects are described in Section 6.1 of OpenID Connect Core
+        1.0 [OpenID.Core]. This algorithm MUST be used both when the Request Object is
+        passed by value (using the request parameter) and when it is passed by reference
+        (using the request_uri parameter). Servers SHOULD support RS256. The value none
+        MAY be used. The default, if omitted, is that any algorithm supported by the OP
+        and the RP MAY be used.
+        """
+        self._validate_claim_value("request_object_signing_alg")
+
+    def validate_request_object_encryption_alg(self):
+        """JWE [JWE] alg algorithm [JWA] the RP is declaring that it may use for
+        encrypting Request Objects sent to the OP.
+
+        This parameter SHOULD be included when symmetric encryption will be used, since
+        this signals to the OP that a client_secret value needs to be returned from
+        which the symmetric key will be derived, that might not otherwise be returned.
+        The RP MAY still use other supported encryption algorithms or send unencrypted
+        Request Objects, even when this parameter is present. If both signing and
+        encryption are requested, the Request Object will be signed then encrypted, with
+        the result being a Nested JWT, as defined in [JWT]. The default, if omitted, is
+        that the RP is not declaring whether it might encrypt any Request Objects.
+        """
+        self._validate_claim_value("request_object_encryption_alg")
+
+    def validate_request_object_encryption_enc(self):
+        """JWE enc algorithm [JWA] the RP is declaring that it may use for encrypting
+        Request Objects sent to the OP.
+
+        If request_object_encryption_alg is specified, the default
+        request_object_encryption_enc value is A128CBC-HS256. When
+        request_object_encryption_enc is included, request_object_encryption_alg MUST
+        also be provided.
+        """
+        if self.get("request_object_encryption_enc") and not self.get(
+            "request_object_encryption_alg"
+        ):
+            raise InvalidClaimError("request_object_encryption_enc")
+
+        if self.get("request_object_encryption_alg"):
+            self.setdefault("request_object_encryption_enc", "A128CBC-HS256")
+
+        self._validate_claim_value("request_object_encryption_enc")
+
+    def validate_request_uris(self):
+        """Array of request_uri values that are pre-registered by the RP for use at the
+        OP.
+
+        These URLs MUST use the https scheme unless the target Request Object is signed
+        in a way that is verifiable by the OP. Servers MAY cache the contents of the
+        files referenced by these URIs and not retrieve them at the time they are used
+        in a request. OPs can require that request_uri values used be pre-registered
+        with the require_request_uri_registration discovery parameter. If the contents
+        of the request file could ever change, these URI values SHOULD include the
+        base64url-encoded SHA-256 hash value of the file contents referenced by the URI
+        as the value of the URI fragment. If the fragment value used for a URI changes,
+        that signals the server that its cached value for that URI with the old fragment
+        value is no longer valid.
+        """
+        self._validate_uri("request_uris")

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,7 @@ Version 1.x.x
 - Implement server-side :rfc:`RFC9207 <9207>`. :issue:`700`
 - ``generate_id_token`` can take a ``kid`` parameter. :pr:`702`
 - More detailed ``InvalidClientError``. :pr:`706`
+- OpenID Connect Dynamic Client Registration implementation. :pr:`707`
 
 Version 1.4.1
 -------------

--- a/docs/specs/oidc.rst
+++ b/docs/specs/oidc.rst
@@ -57,3 +57,31 @@ OpenID Claims
 
 .. autoclass:: UserInfo
     :members:
+
+Dynamic client registration
+---------------------------
+
+The `OpenID Connect Dynamic Client Registration <https://openid.net/specs/openid-connect-registration-1_0.html>`__ implementation is based on :ref:`RFC7591: OAuth 2.0 Dynamic Client Registration Protocol <specs/rfc7591>`. To handle OIDC client registration, you can extend your RFC7591 registration endpoint with OIDC claims::
+
+    from authlib.oauth2.rfc7591 import ClientMetadataClaims as OAuth2ClientMetadataClaims
+    from authlib.oauth2.rfc7591 import ClientRegistrationEndpoint
+    from authlib.oidc.registration import ClientMetadataClaims as OIDCClientMetadataClaims
+
+    class MyClientRegistrationEndpoint(ClientRegistrationEndpoint):
+        ...
+
+        def get_server_metadata(self):
+            ...
+
+    authorization_server.register_endpoint(
+        MyClientRegistrationEndpoint(
+            claims_classes=[OAuth2ClientMetadataClaims, OIDCClientMetadataClaims]
+        )
+    )
+
+
+
+.. automodule:: authlib.oidc.registration
+    :show-inheritance:
+    :members:
+

--- a/tests/core/test_oidc/test_registration.py
+++ b/tests/core/test_oidc/test_registration.py
@@ -1,0 +1,48 @@
+from unittest import TestCase
+
+from authlib.jose.errors import InvalidClaimError
+from authlib.oidc.registration import ClientMetadataClaims
+
+
+class ClientMetadataClaimsTest(TestCase):
+    def test_request_uris(self):
+        claims = ClientMetadataClaims(
+            {"request_uris": ["https://client.test/request_uris"]}, {}
+        )
+        claims.validate()
+
+        claims = ClientMetadataClaims({"request_uris": ["invalid"]}, {})
+        self.assertRaises(InvalidClaimError, claims.validate)
+
+    def test_initiate_login_uri(self):
+        claims = ClientMetadataClaims(
+            {"initiate_login_uri": "https://client.test/initiate_login_uri"}, {}
+        )
+        claims.validate()
+
+        claims = ClientMetadataClaims({"initiate_login_uri": "invalid"}, {})
+        self.assertRaises(InvalidClaimError, claims.validate)
+
+    def test_token_endpoint_auth_signing_alg(self):
+        claims = ClientMetadataClaims({"token_endpoint_auth_signing_alg": "RSA256"}, {})
+        claims.validate()
+
+        # The value none MUST NOT be used.
+        claims = ClientMetadataClaims({"token_endpoint_auth_signing_alg": "none"}, {})
+        self.assertRaises(InvalidClaimError, claims.validate)
+
+    def test_id_token_signed_response_alg(self):
+        claims = ClientMetadataClaims({"id_token_signed_response_alg": "RSA256"}, {})
+        claims.validate()
+
+        # The value none MUST NOT be used.
+        claims = ClientMetadataClaims({"id_token_signed_response_alg": "none"}, {})
+        self.assertRaises(InvalidClaimError, claims.validate)
+
+    def test_default_max_age(self):
+        claims = ClientMetadataClaims({"default_max_age": 1234}, {})
+        claims.validate()
+
+        # The value none MUST NOT be used.
+        claims = ClientMetadataClaims({"default_max_age": "invalid"}, {})
+        self.assertRaises(InvalidClaimError, claims.validate)

--- a/tests/flask/test_oauth2/test_client_registration_endpoint.py
+++ b/tests/flask/test_oauth2/test_client_registration_endpoint.py
@@ -1,9 +1,11 @@
 from flask import json
 
 from authlib.jose import jwt
+from authlib.oauth2.rfc7591 import ClientMetadataClaims as OAuth2ClientMetadataClaims
 from authlib.oauth2.rfc7591 import (
     ClientRegistrationEndpoint as _ClientRegistrationEndpoint,
 )
+from authlib.oidc.registration import ClientMetadataClaims as OIDCClientMetadataClaims
 from tests.util import read_file_path
 
 from .models import Client
@@ -33,7 +35,7 @@ class ClientRegistrationEndpoint(_ClientRegistrationEndpoint):
         return client
 
 
-class ClientRegistrationTest(TestCase):
+class OAuthClientRegistrationTest(TestCase):
     def prepare_data(self, endpoint_cls=None, metadata=None):
         app = self.app
         server = create_authorization_server(app)
@@ -194,5 +196,461 @@ class ClientRegistrationTest(TestCase):
 
         body = {"token_endpoint_auth_method": "none", "client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=headers)
+        resp = json.loads(rv.data)
+        self.assertIn(resp["error"], "invalid_client_metadata")
+
+
+class OIDCClientRegistrationTest(TestCase):
+    def prepare_data(self, metadata=None):
+        self.headers = {"Authorization": "bearer abc"}
+        app = self.app
+        server = create_authorization_server(app)
+
+        class MyClientRegistration(ClientRegistrationEndpoint):
+            def get_server_metadata(self):
+                return metadata
+
+        server.register_endpoint(
+            MyClientRegistration(
+                claims_classes=[OAuth2ClientMetadataClaims, OIDCClientMetadataClaims]
+            )
+        )
+
+        @app.route("/create_client", methods=["POST"])
+        def create_client():
+            return server.create_endpoint_response("client_registration")
+
+        user = User(username="foo")
+        db.session.add(user)
+        db.session.commit()
+
+    def test_application_type(self):
+        self.prepare_data()
+
+        # Nominal case
+        body = {
+            "application_type": "web",
+            "client_name": "Authlib",
+        }
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn("client_id", resp)
+        self.assertEqual(resp["client_name"], "Authlib")
+        self.assertEqual(resp["application_type"], "web")
+
+        # Default case
+        # The default, if omitted, is that any algorithm supported by the OP and the RP MAY be used.
+        body = {
+            "client_name": "Authlib",
+        }
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn("client_id", resp)
+        self.assertEqual(resp["client_name"], "Authlib")
+        self.assertEqual(resp["application_type"], "web")
+
+        # Error case
+        body = {
+            "application_type": "invalid",
+            "client_name": "Authlib",
+        }
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn(resp["error"], "invalid_client_metadata")
+
+    def test_token_endpoint_auth_signing_alg_supported(self):
+        metadata = {
+            "token_endpoint_auth_signing_alg_values_supported": ["RS256", "ES256"]
+        }
+        self.prepare_data(metadata)
+
+        # Nominal case
+        body = {
+            "token_endpoint_auth_signing_alg": "ES256",
+            "client_name": "Authlib",
+        }
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn("client_id", resp)
+        self.assertEqual(resp["client_name"], "Authlib")
+        self.assertEqual(resp["token_endpoint_auth_signing_alg"], "ES256")
+
+        # Default case
+        # The default, if omitted, is that any algorithm supported by the OP and the RP MAY be used.
+        body = {
+            "client_name": "Authlib",
+        }
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn("client_id", resp)
+        self.assertEqual(resp["client_name"], "Authlib")
+
+        # Error case
+        body = {
+            "token_endpoint_auth_signing_alg": "RS512",
+            "client_name": "Authlib",
+        }
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn(resp["error"], "invalid_client_metadata")
+
+    def test_subject_types_supported(self):
+        metadata = {"subject_types_supported": ["public", "pairwise"]}
+        self.prepare_data(metadata)
+
+        # Nominal case
+        body = {"subject_type": "public", "client_name": "Authlib"}
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn("client_id", resp)
+        self.assertEqual(resp["client_name"], "Authlib")
+        self.assertEqual(resp["subject_type"], "public")
+
+        # Error case
+        body = {"subject_type": "invalid", "client_name": "Authlib"}
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn(resp["error"], "invalid_client_metadata")
+
+    def test_id_token_signing_alg_values_supported(self):
+        metadata = {"id_token_signing_alg_values_supported": ["RS256", "ES256"]}
+        self.prepare_data(metadata)
+
+        # Default
+        # The default, if omitted, is RS256.
+        body = {"client_name": "Authlib"}
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn("client_id", resp)
+        self.assertEqual(resp["client_name"], "Authlib")
+        self.assertEqual(resp["id_token_signed_response_alg"], "RS256")
+
+        # Nominal case
+        body = {"id_token_signed_response_alg": "ES256", "client_name": "Authlib"}
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn("client_id", resp)
+        self.assertEqual(resp["client_name"], "Authlib")
+        self.assertEqual(resp["id_token_signed_response_alg"], "ES256")
+
+        # Error case
+        body = {"id_token_signed_response_alg": "RS512", "client_name": "Authlib"}
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn(resp["error"], "invalid_client_metadata")
+
+    def test_id_token_encryption_alg_values_supported(self):
+        metadata = {"id_token_encryption_alg_values_supported": ["RS256", "ES256"]}
+        self.prepare_data(metadata)
+
+        # Default case
+        body = {"client_name": "Authlib"}
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn("client_id", resp)
+        self.assertEqual(resp["client_name"], "Authlib")
+        self.assertNotIn("id_token_encrypted_response_enc", resp)
+
+        # If id_token_encrypted_response_alg is specified, the default
+        # id_token_encrypted_response_enc value is A128CBC-HS256.
+        body = {"id_token_encrypted_response_alg": "RS256", "client_name": "Authlib"}
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn("client_id", resp)
+        self.assertEqual(resp["client_name"], "Authlib")
+        self.assertEqual(resp["id_token_encrypted_response_enc"], "A128CBC-HS256")
+
+        # Nominal case
+        body = {"id_token_encrypted_response_alg": "ES256", "client_name": "Authlib"}
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn("client_id", resp)
+        self.assertEqual(resp["client_name"], "Authlib")
+        self.assertEqual(resp["id_token_encrypted_response_alg"], "ES256")
+
+        # Error case
+        body = {"id_token_encrypted_response_alg": "RS512", "client_name": "Authlib"}
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn(resp["error"], "invalid_client_metadata")
+
+    def test_id_token_encryption_enc_values_supported(self):
+        metadata = {
+            "id_token_encryption_enc_values_supported": ["A128CBC-HS256", "A256GCM"]
+        }
+        self.prepare_data(metadata)
+
+        # Nominal case
+        body = {
+            "id_token_encrypted_response_alg": "RS256",
+            "id_token_encrypted_response_enc": "A256GCM",
+            "client_name": "Authlib",
+        }
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn("client_id", resp)
+        self.assertEqual(resp["client_name"], "Authlib")
+        self.assertEqual(resp["id_token_encrypted_response_alg"], "RS256")
+        self.assertEqual(resp["id_token_encrypted_response_enc"], "A256GCM")
+
+        # Error case: missing id_token_encrypted_response_alg
+        body = {"id_token_encrypted_response_enc": "A256GCM", "client_name": "Authlib"}
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn(resp["error"], "invalid_client_metadata")
+
+        # Error case: alg not in server metadata
+        body = {"id_token_encrypted_response_enc": "A128GCM", "client_name": "Authlib"}
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn(resp["error"], "invalid_client_metadata")
+
+    def test_userinfo_signing_alg_values_supported(self):
+        metadata = {"userinfo_signing_alg_values_supported": ["RS256", "ES256"]}
+        self.prepare_data(metadata)
+
+        # Nominal case
+        body = {"userinfo_signed_response_alg": "ES256", "client_name": "Authlib"}
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn("client_id", resp)
+        self.assertEqual(resp["client_name"], "Authlib")
+        self.assertEqual(resp["userinfo_signed_response_alg"], "ES256")
+
+        # Error case
+        body = {"userinfo_signed_response_alg": "RS512", "client_name": "Authlib"}
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn(resp["error"], "invalid_client_metadata")
+
+    def test_userinfo_encryption_alg_values_supported(self):
+        metadata = {"userinfo_encryption_alg_values_supported": ["RS256", "ES256"]}
+        self.prepare_data(metadata)
+
+        # Nominal case
+        body = {"userinfo_encrypted_response_alg": "ES256", "client_name": "Authlib"}
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn("client_id", resp)
+        self.assertEqual(resp["client_name"], "Authlib")
+        self.assertEqual(resp["userinfo_encrypted_response_alg"], "ES256")
+
+        # Error case
+        body = {"userinfo_encrypted_response_alg": "RS512", "client_name": "Authlib"}
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn(resp["error"], "invalid_client_metadata")
+
+    def test_userinfo_encryption_enc_values_supported(self):
+        metadata = {
+            "userinfo_encryption_enc_values_supported": ["A128CBC-HS256", "A256GCM"]
+        }
+        self.prepare_data(metadata)
+
+        # Default case
+        body = {"client_name": "Authlib"}
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn("client_id", resp)
+        self.assertEqual(resp["client_name"], "Authlib")
+        self.assertNotIn("userinfo_encrypted_response_enc", resp)
+
+        # If userinfo_encrypted_response_alg is specified, the default
+        # userinfo_encrypted_response_enc value is A128CBC-HS256.
+        body = {"userinfo_encrypted_response_alg": "RS256", "client_name": "Authlib"}
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn("client_id", resp)
+        self.assertEqual(resp["client_name"], "Authlib")
+        self.assertEqual(resp["userinfo_encrypted_response_enc"], "A128CBC-HS256")
+
+        # Nominal case
+        body = {
+            "userinfo_encrypted_response_alg": "RS256",
+            "userinfo_encrypted_response_enc": "A256GCM",
+            "client_name": "Authlib",
+        }
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn("client_id", resp)
+        self.assertEqual(resp["client_name"], "Authlib")
+        self.assertEqual(resp["userinfo_encrypted_response_alg"], "RS256")
+        self.assertEqual(resp["userinfo_encrypted_response_enc"], "A256GCM")
+
+        # Error case: no userinfo_encrypted_response_alg
+        body = {"userinfo_encrypted_response_enc": "A256GCM", "client_name": "Authlib"}
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn(resp["error"], "invalid_client_metadata")
+
+        # Error case: alg not in server metadata
+        body = {"userinfo_encrypted_response_enc": "A128GCM", "client_name": "Authlib"}
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn(resp["error"], "invalid_client_metadata")
+
+    def test_acr_values_supported(self):
+        metadata = {
+            "acr_values_supported": [
+                "urn:mace:incommon:iap:silver",
+                "urn:mace:incommon:iap:bronze",
+            ],
+        }
+        self.prepare_data(metadata)
+
+        # Nominal case
+        body = {
+            "default_acr_values": ["urn:mace:incommon:iap:silver"],
+            "client_name": "Authlib",
+        }
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn("client_id", resp)
+        self.assertEqual(resp["client_name"], "Authlib")
+        self.assertEqual(resp["default_acr_values"], ["urn:mace:incommon:iap:silver"])
+
+        # Error case
+        body = {
+            "default_acr_values": [
+                "urn:mace:incommon:iap:silver",
+                "urn:mace:incommon:iap:gold",
+            ],
+            "client_name": "Authlib",
+        }
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn(resp["error"], "invalid_client_metadata")
+
+    def test_request_object_signing_alg_values_supported(self):
+        metadata = {"request_object_signing_alg_values_supported": ["RS256", "ES256"]}
+        self.prepare_data(metadata)
+
+        # Nominal case
+        body = {"request_object_signing_alg": "ES256", "client_name": "Authlib"}
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn("client_id", resp)
+        self.assertEqual(resp["client_name"], "Authlib")
+        self.assertEqual(resp["request_object_signing_alg"], "ES256")
+
+        # Error case
+        body = {"request_object_signing_alg": "RS512", "client_name": "Authlib"}
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn(resp["error"], "invalid_client_metadata")
+
+    def test_request_object_encryption_alg_values_supported(self):
+        metadata = {
+            "request_object_encryption_alg_values_supported": ["RS256", "ES256"]
+        }
+        self.prepare_data(metadata)
+
+        # Nominal case
+        body = {
+            "request_object_encryption_alg": "ES256",
+            "client_name": "Authlib",
+        }
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn("client_id", resp)
+        self.assertEqual(resp["client_name"], "Authlib")
+        self.assertEqual(resp["request_object_encryption_alg"], "ES256")
+
+        # Error case
+        body = {
+            "request_object_encryption_alg": "RS512",
+            "client_name": "Authlib",
+        }
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn(resp["error"], "invalid_client_metadata")
+
+    def test_request_object_encryption_enc_values_supported(self):
+        metadata = {
+            "request_object_encryption_enc_values_supported": [
+                "A128CBC-HS256",
+                "A256GCM",
+            ]
+        }
+        self.prepare_data(metadata)
+
+        # Default case
+        body = {"client_name": "Authlib"}
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn("client_id", resp)
+        self.assertEqual(resp["client_name"], "Authlib")
+        self.assertNotIn("request_object_encryption_enc", resp)
+
+        # If request_object_encryption_alg is specified, the default
+        # request_object_encryption_enc value is A128CBC-HS256.
+        body = {"request_object_encryption_alg": "RS256", "client_name": "Authlib"}
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn("client_id", resp)
+        self.assertEqual(resp["client_name"], "Authlib")
+        self.assertEqual(resp["request_object_encryption_enc"], "A128CBC-HS256")
+
+        # Nominal case
+        body = {
+            "request_object_encryption_alg": "RS256",
+            "request_object_encryption_enc": "A256GCM",
+            "client_name": "Authlib",
+        }
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn("client_id", resp)
+        self.assertEqual(resp["client_name"], "Authlib")
+        self.assertEqual(resp["request_object_encryption_alg"], "RS256")
+        self.assertEqual(resp["request_object_encryption_enc"], "A256GCM")
+
+        # Error case: missing request_object_encryption_alg
+        body = {
+            "request_object_encryption_enc": "A256GCM",
+            "client_name": "Authlib",
+        }
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn(resp["error"], "invalid_client_metadata")
+
+        # Error case: alg not in server metadata
+        body = {
+            "request_object_encryption_enc": "A128GCM",
+            "client_name": "Authlib",
+        }
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn(resp["error"], "invalid_client_metadata")
+
+    def test_require_auth_time(self):
+        self.prepare_data()
+
+        # Default case
+        body = {
+            "client_name": "Authlib",
+        }
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn("client_id", resp)
+        self.assertEqual(resp["client_name"], "Authlib")
+        self.assertEqual(resp["require_auth_time"], False)
+
+        # Nominal case
+        body = {
+            "require_auth_time": True,
+            "client_name": "Authlib",
+        }
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
+        resp = json.loads(rv.data)
+        self.assertIn("client_id", resp)
+        self.assertEqual(resp["client_name"], "Authlib")
+        self.assertEqual(resp["require_auth_time"], True)
+
+        # Error case
+        body = {
+            "require_auth_time": "invalid",
+            "client_name": "Authlib",
+        }
+        rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
         self.assertIn(resp["error"], "invalid_client_metadata")


### PR DESCRIPTION
This implements OpenID Connect Dynamic Client Registration and fixes #705.

Basically, a new claims class is created at `authlib/oidc/registration/claims.py` with all the missing claims.
On the same time I have tuned `RegistrationEndpoint` so it can handle several claims at the same time (this is also in prevision of #500 and the additional `post_logout_redirect_uris` registration claim).

Here is how one can use OIDC Dynamic Client Registration:

```python
    from authlib.oauth2.rfc7591 import ClientMetadataClaims as OAuth2ClientMetadataClaims
    from authlib.oauth2.rfc7591 import ClientRegistrationEndpoint
    from authlib.oidc.registration import ClientMetadataClaims as OIDCClientMetadataClaims

    class MyClientRegistrationEndpoint(ClientRegistrationEndpoint):
        ...

        def get_server_metadata(self):
            ...

    authorization_server.register_endpoint(
        MyClientRegistrationEndpoint(
            claims_classes=[OAuth2ClientMetadataClaims, OIDCClientMetadataClaims]
        )
    )
```