### PR TITLE
Update starlette_client load_config function throwing TypeError

### DIFF
--- a/authlib/integrations/starlette_client/integration.py
+++ b/authlib/integrations/starlette_client/integration.py
@@ -66,7 +66,7 @@ class StarletteIntegration(FrameworkIntegration):
         rv = {}
         for k in params:
             conf_key = f"{name}_{k}".upper()
-            v = oauth.config.get(conf_key, default=None)
+            v = oauth.config.get(conf_key, None)
             if v is not None:
                 rv[k] = v
         return rv


### PR DESCRIPTION
The old syntax throws `TypeError: dict.get() takes no keyword arguments`. I followed the syntax for the [flask load_config function](https://github.com/lepture/authlib/blob/main/authlib/integrations/flask_client/integration.py#L26) to fix the issue.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
