### PR TITLE
fix: Use full entropy from specified oct key size

### DIFF
--- a/authlib/jose/rfc7518/oct_key.py
+++ b/authlib/jose/rfc7518/oct_key.py
@@ -1,8 +1,9 @@
+import secrets
+
 from authlib.common.encoding import to_bytes
 from authlib.common.encoding import to_unicode
 from authlib.common.encoding import urlsafe_b64decode
 from authlib.common.encoding import urlsafe_b64encode
-from authlib.common.security import generate_token
 
 from ..rfc7517 import Key
 
@@ -92,4 +93,4 @@ class OctKey(Key):
         if key_size % 8 != 0:
             raise ValueError("Invalid bit size for oct key")
 
-        return cls.import_key(generate_token(key_size // 8), options)
+        return cls.import_key(secrets.token_bytes(int(key_size / 8)), options)


### PR DESCRIPTION
When generating an oct key the entropy for the key material was only around 0.75 of the entropy requested by the key size. The reason for this was the limited alphabet `generate_token` uses with less than 6 bits per character instead of 8 bits


**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.