### PR TITLE
fix(client): add claims_cls parameter for parse_id_token, #725

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ venv/
 .pytest_cache/
 *.egg
 .idea/
+uv.lock

--- a/authlib/integrations/base_client/sync_openid.py
+++ b/authlib/integrations/base_client/sync_openid.py
@@ -33,7 +33,7 @@ class OpenIDMixin:
         data = resp.json()
         return UserInfo(data)
 
-    def parse_id_token(self, token, nonce, claims_options=None, leeway=120):
+    def parse_id_token(self, token, nonce, claims_options=None, claims_cls=None, leeway=120):
         """Return an instance of UserInfo from token's ``id_token``."""
         if "id_token" not in token:
             return None
@@ -44,11 +44,13 @@ class OpenIDMixin:
             nonce=nonce,
             client_id=self.client_id,
         )
-        if "access_token" in token:
-            claims_params["access_token"] = token["access_token"]
-            claims_cls = CodeIDToken
-        else:
-            claims_cls = ImplicitIDToken
+
+        if claims_cls is None:
+            if "access_token" in token:
+                claims_params["access_token"] = token["access_token"]
+                claims_cls = CodeIDToken
+            else:
+                claims_cls = ImplicitIDToken
 
         metadata = self.load_server_metadata()
         if claims_options is None and "issuer" in metadata:

--- a/authlib/integrations/django_client/apps.py
+++ b/authlib/integrations/django_client/apps.py
@@ -78,15 +78,22 @@ class DjangoOAuth2App(DjangoAppMixin, OAuth2Mixin, OpenIDMixin, BaseApp):
                 "state": request.POST.get("state"),
             }
 
-        claims_options = kwargs.pop("claims_options", None)
         state_data = self.framework.get_state_data(request.session, params.get("state"))
         self.framework.clear_state_data(request.session, params.get("state"))
         params = self._format_state_params(state_data, params)
+
+        claims_options = kwargs.pop("claims_options", None)
+        claims_cls = kwargs.pop("claims_cls", None)
+        leeway = kwargs.pop("leeway", 120)
         token = self.fetch_access_token(**params, **kwargs)
 
         if "id_token" in token and "nonce" in state_data:
             userinfo = self.parse_id_token(
-                token, nonce=state_data["nonce"], claims_options=claims_options
+                token,
+                nonce=state_data["nonce"],
+                claims_options=claims_options,
+                claims_cls=claims_cls,
+                leeway=leeway,
             )
             token["userinfo"] = userinfo
         return token

--- a/authlib/integrations/flask_client/apps.py
+++ b/authlib/integrations/flask_client/apps.py
@@ -100,16 +100,23 @@ class FlaskOAuth2App(FlaskAppMixin, OAuth2Mixin, OpenIDMixin, BaseApp):
                 "state": request.form.get("state"),
             }
 
-        claims_options = kwargs.pop("claims_options", None)
         state_data = self.framework.get_state_data(session, params.get("state"))
         self.framework.clear_state_data(session, params.get("state"))
         params = self._format_state_params(state_data, params)
+
+        claims_options = kwargs.pop("claims_options", None)
+        claims_cls = kwargs.pop("claims_cls", None)
+        leeway = kwargs.pop("leeway", 120)
         token = self.fetch_access_token(**params, **kwargs)
         self.token = token
 
         if "id_token" in token and "nonce" in state_data:
             userinfo = self.parse_id_token(
-                token, nonce=state_data["nonce"], claims_options=claims_options
+                token,
+                nonce=state_data["nonce"],
+                claims_options=claims_options,
+                claims_cls=claims_cls,
+                leeway=leeway,
             )
             token["userinfo"] = userinfo
         return token

--- a/authlib/integrations/starlette_client/apps.py
+++ b/authlib/integrations/starlette_client/apps.py
@@ -78,15 +78,22 @@ class StarletteOAuth2App(
         else:
             session = request.session
 
-        claims_options = kwargs.pop("claims_options", None)
         state_data = await self.framework.get_state_data(session, params.get("state"))
         await self.framework.clear_state_data(session, params.get("state"))
         params = self._format_state_params(state_data, params)
+
+        claims_options = kwargs.pop("claims_options", None)
+        claims_cls = kwargs.pop("claims_cls", None)
+        leeway = kwargs.pop("leeway", 120)
         token = await self.fetch_access_token(**params, **kwargs)
 
         if "id_token" in token and "nonce" in state_data:
             userinfo = await self.parse_id_token(
-                token, nonce=state_data["nonce"], claims_options=claims_options
+                token,
+                nonce=state_data["nonce"],
+                claims_options=claims_options,
+                claims_cls=claims_cls,
+                leeway=leeway,
             )
             token["userinfo"] = userinfo
         return token

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 
 Here you can see the full list of changes between each Authlib release.
 
+Unreleased
+----------
+
+- Add ``claims_cls``` parameter for client's ``parse_id_token`` method.
+
 Version 1.5.1
 -------------
 


### PR DESCRIPTION
By passing a `claims_cls` parameter, developers can use their own claims validator. This will fix #725.