### PR TITLE
Fix invalid characters in 'error_description'

### DIFF
--- a/authlib/jose/errors.py
+++ b/authlib/jose/errors.py
@@ -59,22 +59,22 @@ class KeyMismatchError(JoseError):
 
 class MissingEncryptionAlgorithmError(JoseError):
     error = "missing_encryption_algorithm"
-    description = 'Missing "enc" in header'
+    description = "Missing 'enc' in header"
 
 
 class UnsupportedEncryptionAlgorithmError(JoseError):
     error = "unsupported_encryption_algorithm"
-    description = 'Unsupported "enc" value in header'
+    description = "Unsupported 'enc' value in header"
 
 
 class UnsupportedCompressionAlgorithmError(JoseError):
     error = "unsupported_compression_algorithm"
-    description = 'Unsupported "zip" value in header'
+    description = "Unsupported 'zip' value in header"
 
 
 class InvalidUseError(JoseError):
     error = "invalid_use"
-    description = 'Key "use" is not valid for your usage'
+    description = "Key 'use' is not valid for your usage"
 
 
 class InvalidClaimError(JoseError):
@@ -82,7 +82,7 @@ class InvalidClaimError(JoseError):
 
     def __init__(self, claim):
         self.claim_name = claim
-        description = f'Invalid claim "{claim}"'
+        description = f"Invalid claim '{claim}'"
         super().__init__(description=description)
 
 
@@ -90,7 +90,7 @@ class MissingClaimError(JoseError):
     error = "missing_claim"
 
     def __init__(self, claim):
-        description = f'Missing "{claim}" claim'
+        description = f"Missing '{claim}' claim"
         super().__init__(description=description)
 
 
@@ -98,7 +98,7 @@ class InsecureClaimError(JoseError):
     error = "insecure_claim"
 
     def __init__(self, claim):
-        description = f'Insecure claim "{claim}"'
+        description = f"Insecure claim '{claim}'"
         super().__init__(description=description)
 
 

--- a/authlib/oauth2/base.py
+++ b/authlib/oauth2/base.py
@@ -2,6 +2,24 @@ from authlib.common.errors import AuthlibHTTPError
 from authlib.common.urls import add_params_to_uri
 
 
+def invalid_error_characters(text: str) -> list[str]:
+    """Check whether the string only contains characters from the restricted ASCII set defined in RFC6749 for errors.
+
+    https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1
+    """
+    valid_ranges = [
+        (0x20, 0x21),
+        (0x23, 0x5B),
+        (0x5D, 0x7E),
+    ]
+
+    return [
+        char
+        for char in set(text)
+        if not any(start <= ord(char) <= end for start, end in valid_ranges)
+    ]
+
+
 class OAuth2Error(AuthlibHTTPError):
     def __init__(
         self,
@@ -13,6 +31,17 @@ class OAuth2Error(AuthlibHTTPError):
         redirect_fragment=False,
         error=None,
     ):
+        # Human-readable ASCII [USASCII] text providing
+        # additional information, used to assist the client developer in
+        # understanding the error that occurred.
+        # Values for the "error_description" parameter MUST NOT include
+        # characters outside the set %x20-21 / %x23-5B / %x5D-7E.
+        if description:
+            if chars := invalid_error_characters(description):
+                raise ValueError(
+                    f"Error description contains forbidden characters: {', '.join(chars)}."
+                )
+
         super().__init__(error, description, uri, status_code)
         self.state = state
         self.redirect_uri = redirect_uri

--- a/authlib/oauth2/rfc6749/authorization_server.py
+++ b/authlib/oauth2/rfc6749/authorization_server.py
@@ -264,7 +264,7 @@ class AuthorizationServer:
         :return: Response
         """
         if name not in self._endpoints:
-            raise RuntimeError(f'There is no "{name}" endpoint.')
+            raise RuntimeError(f"There is no '{name}' endpoint.")
 
         endpoints = self._endpoints[name]
         for endpoint in endpoints:

--- a/authlib/oauth2/rfc6749/errors.py
+++ b/authlib/oauth2/rfc6749/errors.py
@@ -217,7 +217,7 @@ class ForbiddenError(OAuth2Error):
 
 class MissingAuthorizationError(ForbiddenError):
     error = "missing_authorization"
-    description = 'Missing "Authorization" in headers.'
+    description = "Missing 'Authorization' in headers."
 
 
 class UnsupportedTokenTypeError(ForbiddenError):
@@ -229,17 +229,17 @@ class UnsupportedTokenTypeError(ForbiddenError):
 
 class MissingCodeException(OAuth2Error):
     error = "missing_code"
-    description = 'Missing "code" in response.'
+    description = "Missing 'code' in response."
 
 
 class MissingTokenException(OAuth2Error):
     error = "missing_token"
-    description = 'Missing "access_token" in response.'
+    description = "Missing 'access_token' in response."
 
 
 class MissingTokenTypeException(OAuth2Error):
     error = "missing_token_type"
-    description = 'Missing "token_type" in response.'
+    description = "Missing 'token_type' in response."
 
 
 class MismatchingStateException(OAuth2Error):

--- a/authlib/oauth2/rfc6749/grants/authorization_code.py
+++ b/authlib/oauth2/rfc6749/grants/authorization_code.py
@@ -213,26 +213,26 @@ class AuthorizationCodeGrant(BaseGrant, AuthorizationEndpointMixin, TokenEndpoin
         log.debug("Validate token request of %r", client)
         if not client.check_grant_type(self.GRANT_TYPE):
             raise UnauthorizedClientError(
-                f'The client is not authorized to use "grant_type={self.GRANT_TYPE}"'
+                f"The client is not authorized to use 'grant_type={self.GRANT_TYPE}'"
             )
 
         code = self.request.form.get("code")
         if code is None:
-            raise InvalidRequestError('Missing "code" in request.')
+            raise InvalidRequestError("Missing 'code' in request.")
 
         # ensure that the authorization code was issued to the authenticated
         # confidential client, or if the client is public, ensure that the
         # code was issued to "client_id" in the request
         authorization_code = self.query_authorization_code(code, client)
         if not authorization_code:
-            raise InvalidGrantError('Invalid "code" in request.')
+            raise InvalidGrantError("Invalid 'code' in request.")
 
         # validate redirect_uri parameter
         log.debug("Validate token redirect_uri of %r", client)
         redirect_uri = self.request.redirect_uri
         original_redirect_uri = authorization_code.get_redirect_uri()
         if original_redirect_uri and redirect_uri != original_redirect_uri:
-            raise InvalidGrantError('Invalid "redirect_uri" in request.')
+            raise InvalidGrantError("Invalid 'redirect_uri' in request.")
 
         # save for create_token_response
         self.request.client = client
@@ -272,7 +272,7 @@ class AuthorizationCodeGrant(BaseGrant, AuthorizationEndpointMixin, TokenEndpoin
 
         user = self.authenticate_user(authorization_code)
         if not user:
-            raise InvalidGrantError('There is no "user" for this code.')
+            raise InvalidGrantError("There is no 'user' for this code.")
         self.request.user = user
 
         scope = authorization_code.get_scope()
@@ -373,7 +373,7 @@ def validate_code_authorization_request(grant):
     response_type = request.response_type
     if not client.check_response_type(response_type):
         raise UnauthorizedClientError(
-            f'The client is not authorized to use "response_type={response_type}"',
+            f"The client is not authorized to use 'response_type={response_type}'",
             state=grant.request.state,
             redirect_uri=redirect_uri,
         )

--- a/authlib/oauth2/rfc6749/grants/base.py
+++ b/authlib/oauth2/rfc6749/grants/base.py
@@ -141,7 +141,7 @@ class AuthorizationEndpointMixin:
             redirect_uri = client.get_default_redirect_uri()
             if not redirect_uri:
                 raise InvalidRequestError(
-                    'Missing "redirect_uri" in request.', state=request.state
+                    "Missing 'redirect_uri' in request.", state=request.state
                 )
             return redirect_uri
 
@@ -157,7 +157,7 @@ class AuthorizationEndpointMixin:
         for param in parameters:
             if len(datalist.get(param, [])) > 1:
                 raise InvalidRequestError(
-                    f'Multiple "{param}" in request.', state=request.state
+                    f"Multiple '{param}' in request.", state=request.state
                 )
 
     def validate_consent_request(self):

--- a/authlib/oauth2/rfc6749/grants/client_credentials.py
+++ b/authlib/oauth2/rfc6749/grants/client_credentials.py
@@ -68,7 +68,7 @@ class ClientCredentialsGrant(BaseGrant, TokenEndpointMixin):
 
         if not client.check_grant_type(self.GRANT_TYPE):
             raise UnauthorizedClientError(
-                f'The client is not authorized to use "grant_type={self.GRANT_TYPE}"'
+                f"The client is not authorized to use 'grant_type={self.GRANT_TYPE}'"
             )
 
         self.request.client = client

--- a/authlib/oauth2/rfc6749/grants/implicit.py
+++ b/authlib/oauth2/rfc6749/grants/implicit.py
@@ -130,7 +130,7 @@ class ImplicitGrant(BaseGrant, AuthorizationEndpointMixin):
         response_type = self.request.response_type
         if not client.check_response_type(response_type):
             raise UnauthorizedClientError(
-                f'The client is not authorized to use "response_type={response_type}"',
+                f"The client is not authorized to use 'response_type={response_type}'",
                 state=self.request.state,
                 redirect_uri=redirect_uri,
                 redirect_fragment=True,

--- a/authlib/oauth2/rfc6749/grants/refresh_token.py
+++ b/authlib/oauth2/rfc6749/grants/refresh_token.py
@@ -41,7 +41,7 @@ class RefreshTokenGrant(BaseGrant, TokenEndpointMixin):
 
         if not client.check_grant_type(self.GRANT_TYPE):
             raise UnauthorizedClientError(
-                f'The client is not authorized to use "grant_type={self.GRANT_TYPE}"'
+                f"The client is not authorized to use 'grant_type={self.GRANT_TYPE}'"
             )
 
         return client
@@ -49,7 +49,7 @@ class RefreshTokenGrant(BaseGrant, TokenEndpointMixin):
     def _validate_request_token(self, client):
         refresh_token = self.request.form.get("refresh_token")
         if refresh_token is None:
-            raise InvalidRequestError('Missing "refresh_token" in request.')
+            raise InvalidRequestError("Missing 'refresh_token' in request.")
 
         token = self.authenticate_refresh_token(refresh_token)
         if not token or not token.check_client(client):
@@ -118,7 +118,7 @@ class RefreshTokenGrant(BaseGrant, TokenEndpointMixin):
         refresh_token = self.request.refresh_token
         user = self.authenticate_user(refresh_token)
         if not user:
-            raise InvalidRequestError('There is no "user" for this token.')
+            raise InvalidRequestError("There is no 'user' for this token.")
 
         client = self.request.client
         token = self.issue_token(user, refresh_token)

--- a/authlib/oauth2/rfc6749/grants/resource_owner_password_credentials.py
+++ b/authlib/oauth2/rfc6749/grants/resource_owner_password_credentials.py
@@ -89,20 +89,20 @@ class ResourceOwnerPasswordCredentialsGrant(BaseGrant, TokenEndpointMixin):
 
         if not client.check_grant_type(self.GRANT_TYPE):
             raise UnauthorizedClientError(
-                f'The client is not authorized to use "grant_type={self.GRANT_TYPE}"'
+                f"The client is not authorized to use 'grant_type={self.GRANT_TYPE}'"
             )
 
         params = self.request.form
         if "username" not in params:
-            raise InvalidRequestError('Missing "username" in request.')
+            raise InvalidRequestError("Missing 'username' in request.")
         if "password" not in params:
-            raise InvalidRequestError('Missing "password" in request.')
+            raise InvalidRequestError("Missing 'password' in request.")
 
         log.debug("Authenticate user of %r", params["username"])
         user = self.authenticate_user(params["username"], params["password"])
         if not user:
             raise InvalidRequestError(
-                'Invalid "username" or "password" in request.',
+                "Invalid 'username' or 'password' in request.",
             )
         self.request.client = client
         self.request.user = user

--- a/authlib/oauth2/rfc7523/assertion.py
+++ b/authlib/oauth2/rfc7523/assertion.py
@@ -21,7 +21,7 @@ def sign_jwt_bearer_assertion(
     if alg:
         header["alg"] = alg
     if "alg" not in header:
-        raise ValueError('Missing "alg" in header')
+        raise ValueError("Missing 'alg' in header")
 
     payload = {"iss": issuer, "aud": audience}
 

--- a/authlib/oauth2/rfc7523/jwt_bearer.py
+++ b/authlib/oauth2/rfc7523/jwt_bearer.py
@@ -102,7 +102,7 @@ class JWTBearerGrant(BaseGrant, TokenEndpointMixin):
         """
         assertion = self.request.form.get("assertion")
         if not assertion:
-            raise InvalidRequestError('Missing "assertion" in request')
+            raise InvalidRequestError("Missing 'assertion' in request")
 
         claims = self.process_assertion_claims(assertion)
         client = self.resolve_issuer_client(claims["iss"])
@@ -110,7 +110,7 @@ class JWTBearerGrant(BaseGrant, TokenEndpointMixin):
 
         if not client.check_grant_type(self.GRANT_TYPE):
             raise UnauthorizedClientError(
-                f'The client is not authorized to use "grant_type={self.GRANT_TYPE}"'
+                f"The client is not authorized to use 'grant_type={self.GRANT_TYPE}'"
             )
 
         self.request.client = client
@@ -120,7 +120,7 @@ class JWTBearerGrant(BaseGrant, TokenEndpointMixin):
         if subject:
             user = self.authenticate_user(subject)
             if not user:
-                raise InvalidGrantError(description='Invalid "sub" value in assertion')
+                raise InvalidGrantError(description="Invalid 'sub' value in assertion")
 
             log.debug("Check client(%s) permission to User(%s)", client, user)
             if not self.has_granted_permission(client, user):

--- a/authlib/oauth2/rfc7636/challenge.py
+++ b/authlib/oauth2/rfc7636/challenge.py
@@ -74,19 +74,19 @@ class CodeChallenge:
             return
 
         if not challenge:
-            raise InvalidRequestError('Missing "code_challenge"')
+            raise InvalidRequestError("Missing 'code_challenge'")
 
         if len(request.datalist.get("code_challenge", [])) > 1:
-            raise InvalidRequestError('Multiple "code_challenge" in request.')
+            raise InvalidRequestError("Multiple 'code_challenge' in request.")
 
         if not CODE_CHALLENGE_PATTERN.match(challenge):
-            raise InvalidRequestError('Invalid "code_challenge"')
+            raise InvalidRequestError("Invalid 'code_challenge'")
 
         if method and method not in self.SUPPORTED_CODE_CHALLENGE_METHOD:
-            raise InvalidRequestError('Unsupported "code_challenge_method"')
+            raise InvalidRequestError("Unsupported 'code_challenge_method'")
 
         if len(request.datalist.get("code_challenge_method", [])) > 1:
-            raise InvalidRequestError('Multiple "code_challenge_method" in request.')
+            raise InvalidRequestError("Multiple 'code_challenge_method' in request.")
 
     def validate_code_verifier(self, grant):
         request: OAuth2Request = grant.request
@@ -94,7 +94,7 @@ class CodeChallenge:
 
         # public client MUST verify code challenge
         if self.required and request.auth_method == "none" and not verifier:
-            raise InvalidRequestError('Missing "code_verifier"')
+            raise InvalidRequestError("Missing 'code_verifier'")
 
         authorization_code = request.authorization_code
         challenge = self.get_authorization_code_challenge(authorization_code)
@@ -105,10 +105,10 @@ class CodeChallenge:
 
         # challenge exists, code_verifier is required
         if not verifier:
-            raise InvalidRequestError('Missing "code_verifier"')
+            raise InvalidRequestError("Missing 'code_verifier'")
 
         if not CODE_VERIFIER_PATTERN.match(verifier):
-            raise InvalidRequestError('Invalid "code_verifier"')
+            raise InvalidRequestError("Invalid 'code_verifier'")
 
         # 4.6. Server Verifies code_verifier before Returning the Tokens
         method = self.get_authorization_code_challenge_method(authorization_code)
@@ -117,7 +117,7 @@ class CodeChallenge:
 
         func = self.CODE_CHALLENGE_METHODS.get(method)
         if not func:
-            raise RuntimeError(f'No verify method for "{method}"')
+            raise RuntimeError(f"No verify method for '{method}'")
 
         # If the values are not equal, an error response indicating
         # "invalid_grant" MUST be returned.

--- a/authlib/oauth2/rfc8628/device_code.py
+++ b/authlib/oauth2/rfc8628/device_code.py
@@ -91,17 +91,17 @@ class DeviceCodeGrant(BaseGrant, TokenEndpointMixin):
         """
         device_code = self.request.data.get("device_code")
         if not device_code:
-            raise InvalidRequestError('Missing "device_code" in payload')
+            raise InvalidRequestError("Missing 'device_code' in payload")
 
         client = self.authenticate_token_endpoint_client()
         if not client.check_grant_type(self.GRANT_TYPE):
             raise UnauthorizedClientError(
-                f'The client is not authorized to use "response_type={self.GRANT_TYPE}"',
+                f"The client is not authorized to use 'response_type={self.GRANT_TYPE}'",
             )
 
         credential = self.query_device_credential(device_code)
         if not credential:
-            raise InvalidRequestError('Invalid "device_code" in payload')
+            raise InvalidRequestError("Invalid 'device_code' in payload")
 
         if credential.get_client_id() != client.get_client_id():
             raise UnauthorizedClientError()

--- a/authlib/oidc/core/grants/hybrid.py
+++ b/authlib/oidc/core/grants/hybrid.py
@@ -51,7 +51,7 @@ class OpenIDHybridGrant(OpenIDImplicitGrant):
     def validate_authorization_request(self):
         if not is_openid_scope(self.request.scope):
             raise InvalidScopeError(
-                'Missing "openid" scope',
+                "Missing 'openid' scope",
                 redirect_uri=self.request.redirect_uri,
                 redirect_fragment=True,
             )

--- a/authlib/oidc/core/grants/implicit.py
+++ b/authlib/oidc/core/grants/implicit.py
@@ -80,7 +80,7 @@ class OpenIDImplicitGrant(ImplicitGrant):
     def validate_authorization_request(self):
         if not is_openid_scope(self.request.scope):
             raise InvalidScopeError(
-                'Missing "openid" scope',
+                "Missing 'openid' scope",
                 redirect_uri=self.request.redirect_uri,
                 redirect_fragment=True,
             )

--- a/authlib/oidc/core/grants/util.py
+++ b/authlib/oidc/core/grants/util.py
@@ -36,7 +36,7 @@ def validate_request_prompt(grant, redirect_uri, redirect_fragment=False):
         # If this parameter contains none with any other value,
         # an error is returned
         raise InvalidRequestError(
-            'Invalid "prompt" parameter.',
+            "Invalid 'prompt' parameter.",
             redirect_uri=redirect_uri,
             redirect_fragment=redirect_fragment,
         )
@@ -53,7 +53,7 @@ def validate_nonce(request, exists_nonce, required=False):
     nonce = request.data.get("nonce")
     if not nonce:
         if required:
-            raise InvalidRequestError('Missing "nonce" in request.')
+            raise InvalidRequestError("Missing 'nonce' in request.")
         return True
 
     if exists_nonce(nonce, request):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,13 @@ Changelog
 
 Here you can see the full list of changes between each Authlib release.
 
+Version 1.5.2
+-------------
+
+**Unreleased**
+
+- Fix invalid characters in ``error_description``. :issue:`720`
+
 Version 1.5.1
 -------------
 

--- a/tests/flask/test_oauth2/test_authorization_code_grant.py
+++ b/tests/flask/test_oauth2/test_authorization_code_grant.py
@@ -255,7 +255,7 @@ class AuthorizationCodeTest(TestCase):
         )
         rv = self.client.get(url)
         self.assertIn(b"invalid_request", rv.data)
-        self.assertIn(b"Multiple+%22response_type%22+in+request.", rv.data)
+        self.assertIn(b"Multiple+%27response_type%27+in+request.", rv.data)
 
     def test_client_secret_post(self):
         self.app.config.update({"OAUTH2_REFRESH_TOKEN_GENERATOR": True})


### PR DESCRIPTION
[RFC7649 §4.1.2.1](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1) indicates that `error_description` have a restricted set of allowed characters, excluding the double-quote symbol `"`.
This PR replaces double quote usage in error description by simple quotes, and add a check for forbidden characters when emitting a OAuth2Error.
Fixes #720

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
