### PR TITLE
Forbid URL fragments in redirect_uris

### DIFF
--- a/authlib/common/urls.py
+++ b/authlib/common/urls.py
@@ -139,6 +139,8 @@ def extract_params(raw):
         return None
 
 
-def is_valid_url(url):
+def is_valid_url(url: str, fragments_allowed=True):
     parsed = urlparse.urlparse(url)
-    return parsed.scheme and parsed.hostname
+    return (
+        parsed.scheme and parsed.hostname and (fragments_allowed or not parsed.fragment)
+    )

--- a/authlib/oauth2/rfc7591/claims.py
+++ b/authlib/oauth2/rfc7591/claims.py
@@ -217,7 +217,7 @@ class ClientMetadataClaims(BaseClaims):
     def _validate_uri(self, key, uri=None):
         if uri is None:
             uri = self.get(key)
-        if uri and not is_valid_url(uri):
+        if uri and not is_valid_url(uri, fragments_allowed=False):
             raise InvalidClaimError(key)
 
     @classmethod

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,13 @@ Changelog
 
 Here you can see the full list of changes between each Authlib release.
 
+Version 1.5.2
+-------------
+
+**Unreleased**
+
+- Forbid fragments in ``redirect_uris``. :issue:`714`
+
 Version 1.5.1
 -------------
 


### PR DESCRIPTION
This PR prevents registration of clients with redirect_uris containing fragments.

Fixes #714
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No
---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
