### PR TITLE
Allow `request_object_signing_alg_values_supported` to not contain 'none' and 'RS256'

### DIFF
--- a/authlib/oidc/discovery/models.py
+++ b/authlib/oidc/discovery/models.py
@@ -159,13 +159,6 @@ class OpenIDProviderMetadata(AuthorizationServerMetadata):
                 '"request_object_signing_alg_values_supported" MUST be JSON array'
             )
 
-        # Servers SHOULD support none and RS256
-        if "none" not in values or "RS256" not in values:
-            raise ValueError(
-                '"request_object_signing_alg_values_supported" '
-                "SHOULD support none and RS256"
-            )
-
     def validate_request_object_encryption_alg_values_supported(self):
         """OPTIONAL. JSON array containing a list of the JWE encryption
         algorithms (alg values) supported by the OP for Request Objects.

--- a/tests/core/test_oidc/test_discovery.py
+++ b/tests/core/test_oidc/test_discovery.py
@@ -94,12 +94,6 @@ class OpenIDProviderMetadataTest(unittest.TestCase):
         self._call_validate_array(
             "request_object_signing_alg_values_supported", ["none", "RS256"]
         )
-        metadata = OpenIDProviderMetadata(
-            {"request_object_signing_alg_values_supported": ["RS512"]}
-        )
-        with self.assertRaises(ValueError) as cm:
-            metadata.validate_request_object_signing_alg_values_supported()
-        self.assertIn("SHOULD support none and RS256", str(cm.exception))
 
     def test_validate_request_object_encryption_alg_values_supported(self):
         self._call_validate_array(


### PR DESCRIPTION
oidc-discovery indicates that 'Servers SHOULD support none and RS256.' but RFC2119 indicates that 'SHOULD' is synonym of 'RECOMMENDED' and not of 'REQUIRED'.

This PR makes 'none' and 'RS256' values optional for `request_object_signing_alg_values_supported`.

fixes #731

> DO NOT SEND ANY SECURITY FIX HERE. Please read "Security Reporting" section
> on README.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
