### PR TITLE
Fix an issue when rfc9207 is enabled and the authorization response is not a 302

### DIFF
--- a/authlib/oauth2/rfc9207/parameter.py
+++ b/authlib/oauth2/rfc9207/parameter.py
@@ -11,7 +11,7 @@ class IssuerParameter:
         )
 
     def add_issuer_parameter(self, hook_type: str, response):
-        if self.get_issuer():
+        if self.get_issuer() and response.location:
             # RFC9207 §2
             # In authorization responses to the client, including error responses,
             # an authorization server supporting this specification MUST indicate

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,12 @@ Changelog
 
 Here you can see the full list of changes between each Authlib release.
 
+Version 1.5.3
+-------------
+
+**Unreleased**
+
+- Fix issue when :rfc:`RFC9207 <9207>` is enabled and the authorization endpoint response is not a redirection. :pr:`733`
 
 Version 1.5.2
 -------------


### PR DESCRIPTION
> DO NOT SEND ANY SECURITY FIX HERE. Please read "Security Reporting" section
> on README.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No


---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
