### PR TITLE
Update Flask OAuth2 example to show error management

### DIFF
--- a/docs/flask/2/authorization-server.rst
+++ b/docs/flask/2/authorization-server.rst
@@ -163,6 +163,7 @@ OAUTH2_ERROR_URIS                  A list of tuple for (``error``, ``error_uri``
 Now define an endpoint for authorization. This endpoint is used by
 ``authorization_code`` and ``implicit`` grants::
 
+    from authlib.oauth2 import OAuth2Error
     from flask import request, render_template
     from your_project.auth import current_user
 
@@ -172,7 +173,11 @@ Now define an endpoint for authorization. This endpoint is used by
         # It can be done with a redirection to the login page, or a login
         # form on this authorization page.
         if request.method == 'GET':
-            grant = server.get_consent_grant(end_user=current_user)
+            try:
+                grant = server.get_consent_grant(end_user=current_user)
+            except OAuth2Error:
+                return authorization.handle_error_response(request, error)
+
             client = grant.client
             scope = client.get_allowed_scope(grant.request.scope)
 


### PR DESCRIPTION
This PR adds a little example of error management with the Flask integration. As [RFC6749 §4.1.2.1](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1) indicates, some errors are expected to be included in the client_uri redirection query string, and some are intended to be displayed to the end-user. I had a hard time understanding the whole error management process, and how to return the correct thing (302 or 400), but in the end `handle_error_response` auto-magically handle errors.

I guess in the end this is how it is supposed to be used, can you confirm this @lepture?