### PR TITLE
Support for 'acr' and 'amr' claims in id_token

### DIFF
--- a/authlib/integrations/sqla_oauth2/tokens_mixins.py
+++ b/authlib/integrations/sqla_oauth2/tokens_mixins.py
@@ -17,6 +17,8 @@ class OAuth2AuthorizationCodeMixin(AuthorizationCodeMixin):
     scope = Column(Text, default="")
     nonce = Column(Text)
     auth_time = Column(Integer, nullable=False, default=lambda: int(time.time()))
+    acr = Column(Text, nullable=True)
+    amr = Column(Text, nullable=True)
 
     code_challenge = Column(Text)
     code_challenge_method = Column(String(48))
@@ -32,6 +34,12 @@ class OAuth2AuthorizationCodeMixin(AuthorizationCodeMixin):
 
     def get_auth_time(self):
         return self.auth_time
+
+    def get_acr(self):
+        return self.acr
+
+    def get_amr(self):
+        return self.amr.split() if self.amr else []
 
     def get_nonce(self):
         return self.nonce

--- a/authlib/oidc/core/grants/code.py
+++ b/authlib/oidc/core/grants/code.py
@@ -79,6 +79,8 @@ class OpenIDToken:
         if authorization_code:
             config["nonce"] = authorization_code.get_nonce()
             config["auth_time"] = authorization_code.get_auth_time()
+            config["acr"] = authorization_code.get_acr()
+            config["amr"] = authorization_code.get_amr()
 
         user_info = self.generate_user_info(request.user, token["scope"])
         id_token = generate_id_token(token, user_info, **config)

--- a/authlib/oidc/core/grants/util.py
+++ b/authlib/oidc/core/grants/util.py
@@ -70,6 +70,8 @@ def generate_id_token(
     exp=3600,
     nonce=None,
     auth_time=None,
+    acr=None,
+    amr=None,
     code=None,
     kid=None,
 ):
@@ -90,6 +92,12 @@ def generate_id_token(
     }
     if nonce:
         payload["nonce"] = nonce
+
+    if acr:
+        payload["acr"] = acr
+
+    if amr:
+        payload["amr"] = amr
 
     if code:
         payload["c_hash"] = to_native(create_half_hash(code, alg))

--- a/authlib/oidc/core/models.py
+++ b/authlib/oidc/core/models.py
@@ -9,3 +9,18 @@ class AuthorizationCodeMixin(_AuthorizationCodeMixin):
     def get_auth_time(self):
         """Get "auth_time" value of the authorization code object."""
         raise NotImplementedError()
+
+    def get_acr(self) -> str:
+        """Get the "acr" (Authentication Method Class) value of the authorization code object."""
+        raise NotImplementedError()
+
+    def get_amr(self) -> list[str]:
+        """Get the "amr" (Authentication Method Reference) value of the authorization code object.
+
+        Have a look at :rfc:`RFC8176 <8176>` to see the full list of registered amr.
+
+            def get_amr(self) -> list[str]:
+                return ["pwd", "otp"]
+
+        """
+        raise NotImplementedError()

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ Version 1.5.3
 **Unreleased**
 
 - Fix issue when :rfc:`RFC9207 <9207>` is enabled and the authorization endpoint response is not a redirection. :pr:`733`
+- Support for ``acr`` and ``amr`` claims in ``id_token``. :issue:`734`
 
 Version 1.5.2
 -------------

--- a/tests/flask/test_oauth2/models.py
+++ b/tests/flask/test_oauth2/models.py
@@ -74,6 +74,8 @@ def save_authorization_code(code, request):
         user_id=request.user.id,
         code_challenge=request.data.get("code_challenge"),
         code_challenge_method=request.data.get("code_challenge_method"),
+        acr="urn:mace:incommon:iap:silver",
+        amr="pwd otp",
     )
     db.session.add(auth_code)
     db.session.commit()

--- a/tests/flask/test_oauth2/test_openid_code_grant.py
+++ b/tests/flask/test_oauth2/test_openid_code_grant.py
@@ -1,3 +1,5 @@
+import time
+
 from flask import current_app
 from flask import json
 
@@ -120,6 +122,9 @@ class OpenIDCodeTest(BaseTestCase):
             claims_options={"iss": {"value": "Authlib"}},
         )
         claims.validate()
+        assert claims["auth_time"] >= int(time.time())
+        assert claims["acr"] == "urn:mace:incommon:iap:silver"
+        assert claims["amr"] == ["pwd", "otp"]
 
     def test_pure_code_flow(self):
         self.prepare_data()


### PR DESCRIPTION
Adds a way to set the `acr` and `amr` claims in `id_token` in the same fashion that `auth_time`.

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.

Fixes #734 