### PR TITLE
Remove deprecated 'check_token_endpoint_auth_method' method

### DIFF
--- a/authlib/oauth2/rfc6749/models.py
+++ b/authlib/oauth2/rfc6749/models.py
@@ -4,8 +4,6 @@
 This module defines how to construct Client, AuthorizationCode and Token.
 """
 
-from authlib.deprecate import deprecate
-
 
 class ClientMixin:
     """Implementation of OAuth 2 Client described in `Section 2`_ with
@@ -109,10 +107,6 @@ class ClientMixin:
         .. _`RFC7591`: https://tools.ietf.org/html/rfc7591
         """
         raise NotImplementedError()
-
-    def check_token_endpoint_auth_method(self, method):
-        deprecate("Please implement ``check_endpoint_auth_method`` instead.")
-        return self.check_endpoint_auth_method(method, "token")
 
     def check_response_type(self, response_type):
         """Validate if the client can handle the given response_type. There

--- a/docs/django/2/authorization-server.rst
+++ b/docs/django/2/authorization-server.rst
@@ -24,11 +24,6 @@ an example.
 Client
 ------
 
-.. versionchanged:: v1.0
-
-    ``check_token_endpoint_auth_method`` is deprecated, developers should
-    implement ``check_endpoint_auth_method`` instead.
-
 A client is an application making protected resource requests on behalf of the
 resource owner and with its authorization. It contains at least three
 information:


### PR DESCRIPTION
The method is deprecated since version 1.0.0 that have been released in 2022.