### PR TITLE
Fix missing 'state' param in authorization error responses

### DIFF
--- a/authlib/oauth2/rfc6749/authenticate_client.py
+++ b/authlib/oauth2/rfc6749/authenticate_client.py
@@ -46,12 +46,10 @@ class ClientAuthentication:
 
         if "client_secret_basic" in methods:
             raise InvalidClientError(
-                state=request.state,
                 status_code=401,
                 description=f"The client cannot authenticate with methods: {methods}",
             )
         raise InvalidClientError(
-            state=request.state,
             description=f"The client cannot authenticate with methods: {methods}",
         )
 
@@ -65,7 +63,7 @@ def authenticate_client_secret_basic(query_client, request):
     """
     client_id, client_secret = extract_basic_authorization(request.headers)
     if client_id and client_secret:
-        client = _validate_client(query_client, client_id, request.state, 401)
+        client = _validate_client(query_client, client_id, 401)
         if client.check_client_secret(client_secret):
             log.debug(f'Authenticate {client_id} via "client_secret_basic" success')
             return client
@@ -80,7 +78,7 @@ def authenticate_client_secret_post(query_client, request):
     client_id = data.get("client_id")
     client_secret = data.get("client_secret")
     if client_id and client_secret:
-        client = _validate_client(query_client, client_id, request.state)
+        client = _validate_client(query_client, client_id)
         if client.check_client_secret(client_secret):
             log.debug(f'Authenticate {client_id} via "client_secret_post" success')
             return client
@@ -93,16 +91,15 @@ def authenticate_none(query_client, request):
     """
     client_id = request.client_id
     if client_id and not request.data.get("client_secret"):
-        client = _validate_client(query_client, client_id, request.state)
+        client = _validate_client(query_client, client_id)
         log.debug(f'Authenticate {client_id} via "none" success')
         return client
     log.debug(f'Authenticate {client_id} via "none" failed')
 
 
-def _validate_client(query_client, client_id, state=None, status_code=400):
+def _validate_client(query_client, client_id, status_code=400):
     if client_id is None:
         raise InvalidClientError(
-            state=state,
             status_code=status_code,
             description="Missing 'client_id' parameter.",
         )
@@ -110,7 +107,6 @@ def _validate_client(query_client, client_id, state=None, status_code=400):
     client = query_client(client_id)
     if not client:
         raise InvalidClientError(
-            state=state,
             status_code=status_code,
             description="The client does not exist on this server.",
         )

--- a/authlib/oauth2/rfc6749/grants/authorization_code.py
+++ b/authlib/oauth2/rfc6749/grants/authorization_code.py
@@ -150,7 +150,7 @@ class AuthorizationCodeGrant(BaseGrant, AuthorizationEndpointMixin, TokenEndpoin
         :returns: (status_code, body, headers)
         """
         if not grant_user:
-            raise AccessDeniedError(state=self.request.state, redirect_uri=redirect_uri)
+            raise AccessDeniedError(redirect_uri=redirect_uri)
 
         self.request.user = grant_user
 
@@ -358,14 +358,12 @@ def validate_code_authorization_request(grant):
 
     if client_id is None:
         raise InvalidClientError(
-            state=request.state,
             description="Missing 'client_id' parameter.",
         )
 
     client = grant.server.query_client(client_id)
     if not client:
         raise InvalidClientError(
-            state=request.state,
             description="The client does not exist on this server.",
         )
 
@@ -374,7 +372,6 @@ def validate_code_authorization_request(grant):
     if not client.check_response_type(response_type):
         raise UnauthorizedClientError(
             f"The client is not authorized to use 'response_type={response_type}'",
-            state=grant.request.state,
             redirect_uri=redirect_uri,
         )
 

--- a/authlib/oauth2/rfc6749/grants/base.py
+++ b/authlib/oauth2/rfc6749/grants/base.py
@@ -86,8 +86,7 @@ class BaseGrant:
     def validate_requested_scope(self):
         """Validate if requested scope is supported by Authorization Server."""
         scope = self.request.scope
-        state = self.request.state
-        return self.server.validate_requested_scope(scope, state)
+        return self.server.validate_requested_scope(scope)
 
     def register_hook(self, hook_type, hook):
         if hook_type not in self._hooks:
@@ -134,7 +133,6 @@ class AuthorizationEndpointMixin:
             if not client.check_redirect_uri(request.redirect_uri):
                 raise InvalidRequestError(
                     f"Redirect URI {request.redirect_uri} is not supported by client.",
-                    state=request.state,
                 )
             return request.redirect_uri
         else:

--- a/authlib/oauth2/rfc6749/grants/implicit.py
+++ b/authlib/oauth2/rfc6749/grants/implicit.py
@@ -131,7 +131,6 @@ class ImplicitGrant(BaseGrant, AuthorizationEndpointMixin):
         if not client.check_response_type(response_type):
             raise UnauthorizedClientError(
                 f"The client is not authorized to use 'response_type={response_type}'",
-                state=self.request.state,
                 redirect_uri=redirect_uri,
                 redirect_fragment=True,
             )
@@ -222,6 +221,4 @@ class ImplicitGrant(BaseGrant, AuthorizationEndpointMixin):
             headers = [("Location", uri)]
             return 302, "", headers
         else:
-            raise AccessDeniedError(
-                state=state, redirect_uri=redirect_uri, redirect_fragment=True
-            )
+            raise AccessDeniedError(redirect_uri=redirect_uri, redirect_fragment=True)

--- a/authlib/oidc/core/grants/implicit.py
+++ b/authlib/oidc/core/grants/implicit.py
@@ -104,7 +104,7 @@ class OpenIDImplicitGrant(ImplicitGrant):
             if state:
                 params.append(("state", state))
         else:
-            error = AccessDeniedError(state=state)
+            error = AccessDeniedError()
             params = error.get_body()
 
         # http://openid.net/specs/oauth-v2-multiple-response-types-1_0.html#ResponseModes

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ Version 1.5.3
 **Unreleased**
 
 - Fix issue when :rfc:`RFC9207 <9207>` is enabled and the authorization endpoint response is not a redirection. :pr:`733`
+- Fix missing ``state`` parameter in authorization error responses. :issue:`525`
 
 Version 1.5.2
 -------------

--- a/tests/flask/test_oauth2/test_openid_code_grant.py
+++ b/tests/flask/test_oauth2/test_openid_code_grant.py
@@ -214,6 +214,24 @@ class OpenIDCodeTest(BaseTestCase):
         rv = self.client.get("/oauth/authorize?" + query)
         self.assertEqual(rv.data, b"login")
 
+    def test_prompt_none_not_logged(self):
+        self.prepare_data()
+        params = [
+            ("response_type", "code"),
+            ("client_id", "code-client"),
+            ("state", "bar"),
+            ("nonce", "abc"),
+            ("scope", "openid profile"),
+            ("redirect_uri", "https://a.b"),
+            ("prompt", "none"),
+        ]
+        query = url_encode(params)
+        rv = self.client.get("/oauth/authorize?" + query)
+
+        params = dict(url_decode(urlparse.urlparse(rv.location).query))
+        self.assertEqual(params["error"], "login_required")
+        self.assertEqual(params["state"], "bar")
+
 
 class RSAOpenIDCodeTest(BaseTestCase):
     def config_app(self):


### PR DESCRIPTION
This is a refactoring that catches all errors from the authorization endpoint and dynamically add a `state` parameter instead of manually setting it on all errors.
This ensures the state parameter will always be present, and developers don't have to explicitly set (or forget) it.

Fixes #525 