### PR TITLE
Fix `response_types` order unwanted strictness during dynamic client registration

### DIFF
--- a/authlib/oauth2/rfc7591/claims.py
+++ b/authlib/oauth2/rfc7591/claims.py
@@ -240,13 +240,20 @@ class ClientMetadataClaims(BaseClaims):
             options["scope"] = {"validate": _validate_scope}
 
         if response_types_supported is not None:
-            response_types_supported = set(response_types_supported)
+            response_types_supported = [
+                set(items.split()) for items in response_types_supported
+            ]
 
             def _validate_response_types(claims, value):
                 # If omitted, the default is that the client will use only the "code"
                 # response type.
-                response_types = set(value) if value else {"code"}
-                return response_types_supported.issuperset(response_types)
+                response_types = (
+                    [set(items.split()) for items in value] if value else [{"code"}]
+                )
+                return all(
+                    response_type in response_types_supported
+                    for response_type in response_types
+                )
 
             options["response_types"] = {"validate": _validate_response_types}
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Version 1.5.3
 - Fix missing ``state`` parameter in authorization error responses. :issue:`525`
 - Support for ``acr`` and ``amr`` claims in ``id_token``. :issue:`734`
 - Support for the ``none`` JWS algorithm.
+- Fix ``response_types`` strict order during dynamic client registration. :issue:`760`
 
 Version 1.5.2
 -------------

--- a/tests/flask/test_oauth2/test_client_registration_endpoint.py
+++ b/tests/flask/test_oauth2/test_client_registration_endpoint.py
@@ -131,11 +131,22 @@ class OAuthClientRegistrationTest(TestCase):
         self.assertIn(resp["error"], "invalid_client_metadata")
 
     def test_response_types_supported(self):
-        metadata = {"response_types_supported": ["code"]}
+        metadata = {"response_types_supported": ["code", "code id_token"]}
         self.prepare_data(metadata=metadata)
 
         headers = {"Authorization": "bearer abc"}
         body = {"response_types": ["code"], "client_name": "Authlib"}
+        rv = self.client.post("/create_client", json=body, headers=headers)
+        resp = json.loads(rv.data)
+        self.assertIn("client_id", resp)
+        self.assertEqual(resp["client_name"], "Authlib")
+
+        # The items order should not matter
+        # Extension response types MAY contain a space-delimited (%x20) list of
+        # values, where the order of values does not matter (e.g., response
+        # type "a b" is the same as "b a").
+        headers = {"Authorization": "bearer abc"}
+        body = {"response_types": ["id_token code"], "client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=headers)
         resp = json.loads(rv.data)
         self.assertIn("client_id", resp)


### PR DESCRIPTION
As per RFC6749 §3.1.1:

    Extension response types MAY contain a space-delimited (%x20) list of
    values, where the order of values does not matter (e.g., response
    type "a b" is the same as "b a").

Fix #760