### PR TITLE
`unsupported_response_type` errors are redirected

### DIFF
--- a/authlib/oauth2/rfc6749/authorization_server.py
+++ b/authlib/oauth2/rfc6749/authorization_server.py
@@ -231,7 +231,12 @@ class AuthorizationServer:
         for grant_cls, extensions in self._authorization_grants:
             if grant_cls.check_authorization_endpoint(request):
                 return _create_grant(grant_cls, extensions, request, self)
-        raise UnsupportedResponseTypeError(request.response_type)
+
+        raise UnsupportedResponseTypeError(
+            f"The response type '{request.response_type}' is not supported by the server.",
+            request.response_type,
+            redirect_uri=request.redirect_uri,
+        )
 
     def get_consent_grant(self, request=None, end_user=None):
         """Validate current HTTP request for authorization page. This page

--- a/authlib/oauth2/rfc6749/errors.py
+++ b/authlib/oauth2/rfc6749/errors.py
@@ -140,8 +140,8 @@ class UnsupportedResponseTypeError(OAuth2Error):
 
     error = "unsupported_response_type"
 
-    def __init__(self, response_type):
-        super().__init__()
+    def __init__(self, response_type, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.response_type = response_type
 
     def get_error_description(self):

--- a/tests/flask/test_oauth2/test_openid_hybrid_grant.py
+++ b/tests/flask/test_oauth2/test_openid_hybrid_grant.py
@@ -149,8 +149,8 @@ class OpenIDCodeTest(TestCase):
                 "user_id": "1",
             },
         )
-        resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "unsupported_response_type")
+        params = dict(url_decode(urlparse.urlparse(rv.location).query))
+        self.assertEqual(params["error"], "unsupported_response_type")
 
     def test_invalid_scope(self):
         self.prepare_data()


### PR DESCRIPTION
As indicated by [RFC6749 §4.1.2.1](https://www.rfc-editor.org/rfc/rfc6749.html#section-4.1.2.1), authorization endpoint errors except client and redirect_uri errors result in a redirection:

```
   If the resource owner denies the access request or if the request
   fails for reasons other than a missing or invalid redirection URI,
   the authorization server informs the client by adding the following
   parameters to the query component of the redirection URI using the
   "application/x-www-form-urlencoded" format
```