### PR TITLE
Move from pre-commit to prek

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,7 +25,7 @@ Please indicate if this PR is related to other issues or PRs.
 
 **Checklist**
 
-- [ ] You ran the linters with ``pre-commit``.
+- [ ] You ran the linters with ``prek``.
 - [ ] You wrote unit test to demonstrate the bug you are fixing, or to stress the feature you are bringing.
 - [ ] You reached 100% of code coverage on the code you edited, without abusive use of `pragma: no cover`
 - [ ] If this PR is about a new feature, or a behavior change, you have updated the documentation accordingly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dev = [
     "coverage",
     "cryptography",
     "diff-cover>=9.6.0",
-    "pre-commit-uv>=4.1.4",
+    "prek>=0.1.3",
     "pytest",
     "pytest-asyncio",
     "pytest-env",


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Remove the `pre-commit` dependency and use `prek` instead.

**Checklist**

- [x] You ran the linters with ``pre-commit``.

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
