### PR TITLE
Fix: Handle unparseable expires_at by falling back to expires_in

### DIFF
--- a/authlib/oauth2/rfc6749/wrappers.py
+++ b/authlib/oauth2/rfc6749/wrappers.py
@@ -4,7 +4,14 @@ import time
 class OAuth2Token(dict):
     def __init__(self, params):
         if params.get("expires_at"):
-            params["expires_at"] = int(params["expires_at"])
+                        try:
+
+                                            params["expires_at"] = int(params["expires_at"])
+                                        except (ValueError, TypeError):
+                                                            # If expires_at cannot be parsed, fall back to expires_in
+                                                            if params.get("expires_in"):
+                                                                                    params["expires_at"] = int(time.time()) + int(params["expires_in"])
+
         elif params.get("expires_in"):
             params["expires_at"] = int(time.time()) + int(params["expires_in"])
         super().__init__(params)


### PR DESCRIPTION
Fixes #833

When an OAuth2/OIDC server returns expires_at as a string that cannot be parsed as an integer, the OAuth2Token initialization now gracefully handles the ValueError/TypeError and falls back to using expires_in to calculate the expiration time.

This prevents token creation from failing when expires_at is in a non-standard format while expires_in is available.

<!--
> DO NOT SEND ANY SECURITY FIX HERE. Please read "Security Reporting" section
> on README.
-->

**What kind of change does this PR introduce?**

<!--
Describe whether your change is:
- a bugfix
- a feature implementation
- a code style update
- a refactoring
- or anything else

Please indicate if this PR is related to other issues or PRs.
-->

**Does this PR introduce a breaking change?**

<!--
- If yes, please describe the impact and migration path for existing applications:
- If no, please delete the above question and this text message.
-->

**Checklist**

- [ ] The commits follow the [conventional commits](https://www.conventionalcommits.org) specification.
- [ ] You ran the linters with ``prek``.
- [ ] You wrote unit test to demonstrate the bug you are fixing, or to stress the feature you are bringing.
- [ ] You reached 100% of code coverage on the code you edited, without abusive use of `pragma: no cover`
- [ ] If this PR is about a new feature, or a behavior change, you have updated the documentation accordingly.

---

- [ ] You consent that the copyright of your pull request source code belongs to Authlib's author.
