### PR TITLE
Client `id_token_signed_response_alg` metadata takes precedence over server `get_jwt_config`

### DIFF
--- a/authlib/oidc/core/grants/code.py
+++ b/authlib/oidc/core/grants/code.py
@@ -83,9 +83,7 @@ class OpenIDToken:
 
         # Per OpenID Connect Registration 1.0 Section 2:
         # Use client's id_token_signed_response_alg if specified
-        if not config.get("alg") and (
-            client_alg := request.client.id_token_signed_response_alg
-        ):
+        if client_alg := request.client.id_token_signed_response_alg:
             config["alg"] = client_alg
 
         if authorization_code:

--- a/authlib/oidc/core/grants/implicit.py
+++ b/authlib/oidc/core/grants/implicit.py
@@ -151,9 +151,7 @@ class OpenIDImplicitGrant(ImplicitGrant):
 
         # Per OpenID Connect Registration 1.0 Section 2:
         # Use client's id_token_signed_response_alg if specified
-        if not config.get("alg") and (
-            client_alg := self.request.client.id_token_signed_response_alg
-        ):
+        if client_alg := self.request.client.id_token_signed_response_alg:
             if client_alg == "none":
                 # According to oidc-registration §2 the 'none' alg is not valid in
                 # implicit flows:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,16 @@ Changelog
 
 Here you can see the full list of changes between each Authlib release.
 
+Version 1.7.0
+-------------
+
+**Unreleased**
+
+**Breaking changes**:
+
+- Client ``id_token_signed_response_alg`` metadata now takes precedence over server
+  ``get_jwt_config()`` when signing ``id_token``. :issue:`806`
+
 Version 1.6.5
 -------------
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

When signing id_tokens, the client `id_token_signed_response_alg` metadata is used in priority.
Fixes #806.

**Does this PR introduce a breaking change?**

Before this, the value defined in `get_jwt_config` was used in priority, and `id_token_signed_response_alg` was only used if `get_jwt_config` does not provide `alg`.

This should only be merged for 1.7

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
