### PR TITLE
`get_jwt_config` takes a `client` parameter.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,13 @@ Changelog
 
 Here you can see the full list of changes between each Authlib release.
 
+Version 1.6.6
+-------------
+
+**Released on Dec 11, 2025**
+
+- ``get_jwt_config`` takes a ``client`` parameter.
+
 Version 1.6.5
 -------------
 

--- a/tests/clients/test_requests/test_oauth2_session.py
+++ b/tests/clients/test_requests/test_oauth2_session.py
@@ -324,16 +324,16 @@ def test_token_status3():
 
 
 def test_expires_in_used_when_expires_at_unparseable():
-    """Test that expires_in is used as fallback when expires_at is unparseable."""
+    """Test that expires_in is used as fallback when expires_at is unparsable."""
     token = dict(
         access_token="a",
         token_type="bearer",
         expires_in=3600,  # 1 hour from now
-        expires_at="2024-01-01T00:00:00Z",  # Unparseable - should fall back to expires_in
+        expires_at="2024-01-01T00:00:00Z",  # Unparsable - should fall back to expires_in
     )
     sess = OAuth2Session("foo", token=token)
 
-    # The token should use expires_in since expires_at is unparseable
+    # The token should use expires_in since expires_at is unparsable
     # So it should be considered expired with leeway > 3600
     assert sess.token.is_expired(leeway=3700) is True
     # And not expired with leeway < 3600

--- a/tests/flask/test_oauth2/test_openid_hybrid_grant.py
+++ b/tests/flask/test_oauth2/test_openid_hybrid_grant.py
@@ -26,7 +26,7 @@ def server(server):
             return save_authorization_code(code, request)
 
     class OpenIDCode(_OpenIDCode):
-        def get_jwt_config(self, grant):
+        def get_jwt_config(self, grant, client):
             return dict(JWT_CONFIG)
 
         def exists_nonce(self, nonce, request):
@@ -39,7 +39,7 @@ def server(server):
         def save_authorization_code(self, code, request):
             return save_authorization_code(code, request)
 
-        def get_jwt_config(self):
+        def get_jwt_config(self, client):
             return dict(JWT_CONFIG)
 
         def exists_nonce(self, nonce, request):

--- a/tests/flask/test_oauth2/test_password_grant.py
+++ b/tests/flask/test_oauth2/test_password_grant.py
@@ -26,7 +26,7 @@ def client(client, db):
 
 
 class IDToken(OpenIDToken):
-    def get_jwt_config(self, grant):
+    def get_jwt_config(self, grant, client):
         return {
             "iss": "Authlib",
             "key": "secret",


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Add a `client` parameter to `get_jwt_config` so people can use `client.id_token_signed_response_alg` in `get_jwt_config`.

Supersedes #843
Related to #806. It does not fix it because `client.id_token_signed_response_alg` should be the default, but at least it allows for a smooth transition.

**Checklist**

- [x] The commits follow the [conventional commits](https://www.conventionalcommits.org) specification.
- [x] You ran the linters with ``prek``.
- [x] You wrote unit test to demonstrate the bug you are fixing, or to stress the feature you are bringing.
- [x] You reached 100% of code coverage on the code you edited, without abusive use of `pragma: no cover`
- [x] If this PR is about a new feature, or a behavior change, you have updated the documentation accordingly.

---

- [ ] You consent that the copyright of your pull request source code belongs to Authlib's author.
