### PR TITLE
Authorization and token endpoints request empty scope parameter management

### DIFF
--- a/authlib/oauth2/rfc6749/requests.py
+++ b/authlib/oauth2/rfc6749/requests.py
@@ -90,6 +90,7 @@ class OAuth2Request(OAuth2Payload):
         self.authorization_code = None
         self.refresh_token = None
         self.credential = None
+        self._scope = None
 
     @property
     def args(self):
@@ -151,11 +152,13 @@ class OAuth2Request(OAuth2Payload):
 
     @property
     def scope(self) -> str:
-        deprecate(
-            "'request.scope' is deprecated in favor of 'request.payload.scope'",
-            version="1.8",
-        )
+        if self._scope is not None:
+            return self._scope
         return self.payload.scope
+
+    @scope.setter
+    def scope(self, value: str):
+        self._scope = value
 
     @property
     def state(self):

--- a/authlib/oauth2/rfc6750/token.py
+++ b/authlib/oauth2/rfc6750/token.py
@@ -1,3 +1,6 @@
+from ..rfc6749.errors import InvalidScopeError
+
+
 class BearerTokenGenerator:
     """Bearer token generator which can create the payload for token response
     by OAuth 2 server. A typical token response would be:
@@ -52,8 +55,20 @@ class BearerTokenGenerator:
 
     @staticmethod
     def get_allowed_scope(client, scope):
-        if scope:
-            scope = client.get_allowed_scope(scope)
+        """Get the allowed scope for token generation.
+
+        Per RFC 6749 Section 3.3, if the client omits the scope parameter,
+        the authorization server MUST either process the request using a
+        pre-defined default value or fail the request indicating an invalid scope.
+
+        :param client: the client making the request
+        :param scope: the requested scope (may be None if omitted)
+        :return: the allowed scope string
+        :raises InvalidScopeError: if client.get_allowed_scope returns None
+        """
+        scope = client.get_allowed_scope(scope)
+        if scope is None:
+            raise InvalidScopeError()
         return scope
 
     def generate(

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,15 @@ Changelog
 
 Here you can see the full list of changes between each Authlib release.
 
+Version 1.6.7
+-------------
+
+**Unreleased**
+
+- Per RFC 6749 Section 3.3, the ``scope`` parameter is now optional at both
+  authorization and token endpoints. ``client.get_allowed_scope()`` is called
+  to determine the default scope when omitted. :issue:`845`
+
 Version 1.6.6
 -------------
 

--- a/tests/flask/test_oauth2/models.py
+++ b/tests/flask/test_oauth2/models.py
@@ -103,7 +103,7 @@ def save_authorization_code(code, request):
         code=code,
         client_id=client.client_id,
         redirect_uri=request.payload.redirect_uri,
-        scope=request.payload.scope,
+        scope=request.scope,
         nonce=request.payload.data.get("nonce"),
         user_id=request.user.id,
         code_challenge=request.payload.data.get("code_challenge"),


### PR DESCRIPTION
- call `client.get_allowed_scope` at the authorization endpoint (in addition to the token endpoint)
- raise `InvalidScopeError()` if `get_allowed_scope` returns None

I wonder if `get_allowed_scope` is still a good name, maybe `validate_scope` would be better?

Fixes #845

- [x] The commits follow the [conventional commits](https://www.conventionalcommits.org) specification.
- [x] You ran the linters with ``prek``.
- [x] You wrote unit test to demonstrate the bug you are fixing, or to stress the feature you are bringing.
- [x] You reached 100% of code coverage on the code you edited, without abusive use of `pragma: no cover`
- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
