### PR TITLE
Allow composition of AuthorizationServerMetadata

### DIFF
--- a/authlib/oauth2/rfc9101/discovery.py
+++ b/authlib/oauth2/rfc9101/discovery.py
@@ -1,9 +1,21 @@
-from authlib.oidc.discovery.models import _validate_boolean_value
+from authlib.oauth2.rfc8414.models import validate_boolean_value
 
 
 class AuthorizationServerMetadata(dict):
+    """Authorization Server Metadata extension for RFC9101 (JAR).
+
+    This class can be used with
+    :meth:`~authlib.oauth2.rfc8414.AuthorizationServerMetadata.validate`
+    to validate JAR-specific metadata::
+
+        from authlib.oauth2 import rfc8414, rfc9101
+
+        metadata = rfc8414.AuthorizationServerMetadata(data)
+        metadata.validate(metadata_classes=[rfc9101.AuthorizationServerMetadata])
+    """
+
     REGISTRY_KEYS = ["require_signed_request_object"]
 
     def validate_require_signed_request_object(self):
         """Indicates where authorization request needs to be protected as Request Object and provided through either request or request_uri parameter."""
-        _validate_boolean_value(self, "require_signed_request_object")
+        validate_boolean_value(self, "require_signed_request_object")

--- a/authlib/oauth2/rfc9207/__init__.py
+++ b/authlib/oauth2/rfc9207/__init__.py
@@ -1,3 +1,4 @@
+from .discovery import AuthorizationServerMetadata
 from .parameter import IssuerParameter
 
-__all__ = ["IssuerParameter"]
+__all__ = ["AuthorizationServerMetadata", "IssuerParameter"]

--- a/authlib/oauth2/rfc9207/discovery.py
+++ b/authlib/oauth2/rfc9207/discovery.py
@@ -1,0 +1,25 @@
+from authlib.oauth2.rfc8414.models import validate_boolean_value
+
+
+class AuthorizationServerMetadata(dict):
+    """Authorization Server Metadata extension for RFC9207.
+
+    This class can be used with
+    :meth:`~authlib.oauth2.rfc8414.AuthorizationServerMetadata.validate`
+    to validate RFC9207-specific metadata::
+
+        from authlib.oauth2 import rfc8414, rfc9207
+
+        metadata = rfc8414.AuthorizationServerMetadata(data)
+        metadata.validate(metadata_classes=[rfc9207.AuthorizationServerMetadata])
+    """
+
+    REGISTRY_KEYS = ["authorization_response_iss_parameter_supported"]
+
+    def validate_authorization_response_iss_parameter_supported(self):
+        """Boolean parameter indicating whether the authorization server
+        provides the iss parameter in the authorization response.
+
+        If omitted, the default value is false.
+        """
+        validate_boolean_value(self, "authorization_response_iss_parameter_supported")

--- a/authlib/oidc/discovery/models.py
+++ b/authlib/oidc/discovery/models.py
@@ -1,8 +1,21 @@
 from authlib.oauth2.rfc8414 import AuthorizationServerMetadata
 from authlib.oauth2.rfc8414.models import validate_array_value
+from authlib.oauth2.rfc8414.models import validate_boolean_value
 
 
 class OpenIDProviderMetadata(AuthorizationServerMetadata):
+    """OpenID Provider Metadata for OpenID Connect Discovery.
+
+    The :meth:`validate` method can compose extension classes via the
+    ``metadata_classes`` parameter. For example, to validate RP-Initiated
+    Logout metadata::
+
+        from authlib.oidc import discovery, rpinitiated
+
+        metadata = discovery.OpenIDProviderMetadata(data)
+        metadata.validate(metadata_classes=[rpinitiated.OpenIDProviderMetadata])
+    """
+
     REGISTRY_KEYS = [
         "issuer",
         "authorization_endpoint",
@@ -230,21 +243,21 @@ class OpenIDProviderMetadata(AuthorizationServerMetadata):
         the claims parameter, with true indicating support. If omitted, the
         default value is false.
         """
-        _validate_boolean_value(self, "claims_parameter_supported")
+        validate_boolean_value(self, "claims_parameter_supported")
 
     def validate_request_parameter_supported(self):
         """OPTIONAL. Boolean value specifying whether the OP supports use of
         the request parameter, with true indicating support. If omitted, the
         default value is false.
         """
-        _validate_boolean_value(self, "request_parameter_supported")
+        validate_boolean_value(self, "request_parameter_supported")
 
     def validate_request_uri_parameter_supported(self):
         """OPTIONAL. Boolean value specifying whether the OP supports use of
         the request_uri parameter, with true indicating support. If omitted,
         the default value is true.
         """
-        _validate_boolean_value(self, "request_uri_parameter_supported")
+        validate_boolean_value(self, "request_uri_parameter_supported")
 
     def validate_require_request_uri_registration(self):
         """OPTIONAL. Boolean value specifying whether the OP requires any
@@ -252,7 +265,7 @@ class OpenIDProviderMetadata(AuthorizationServerMetadata):
         registration parameter. Pre-registration is REQUIRED when the value
         is true. If omitted, the default value is false.
         """
-        _validate_boolean_value(self, "require_request_uri_registration")
+        validate_boolean_value(self, "require_request_uri_registration")
 
     @property
     def claim_types_supported(self):
@@ -278,10 +291,3 @@ class OpenIDProviderMetadata(AuthorizationServerMetadata):
     def require_request_uri_registration(self):
         # If omitted, the default value is false.
         return self.get("require_request_uri_registration", False)
-
-
-def _validate_boolean_value(metadata, key):
-    if key not in metadata:
-        return
-    if metadata[key] not in (True, False):
-        raise ValueError(f'"{key}" MUST be boolean')

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Version 1.6.7
   authorization and token endpoints. ``client.get_allowed_scope()`` is called
   to determine the default scope when omitted. :issue:`845`
 - Stop support for Python 3.9, start support Python 3.14. :pr:`850`
+- Allow ``AuthorizationServerMetadata.validate()`` to compose with RFC extension classes.
 
 Version 1.6.6
 -------------

--- a/tests/core/test_oauth2/test_rfc8414.py
+++ b/tests/core/test_oauth2/test_rfc8414.py
@@ -1,5 +1,6 @@
 import pytest
 
+from authlib.oauth2 import rfc9101
 from authlib.oauth2.rfc8414 import AuthorizationServerMetadata
 from authlib.oauth2.rfc8414 import get_well_known_url
 
@@ -437,3 +438,25 @@ def test_validate_code_challenge_methods_supported():
         {"code_challenge_methods_supported": ["S256"]}
     )
     metadata.validate_code_challenge_methods_supported()
+
+
+def test_validate_with_metadata_classes():
+    """Test that validate() can compose metadata extension classes."""
+
+    base_metadata = {
+        "issuer": "https://provider.test",
+        "authorization_endpoint": "https://provider.test/auth",
+        "token_endpoint": "https://provider.test/token",
+        "response_types_supported": ["code"],
+    }
+
+    metadata = AuthorizationServerMetadata(
+        {**base_metadata, "require_signed_request_object": True}
+    )
+    metadata.validate(metadata_classes=[rfc9101.AuthorizationServerMetadata])
+
+    metadata = AuthorizationServerMetadata(
+        {**base_metadata, "require_signed_request_object": "invalid"}
+    )
+    with pytest.raises(ValueError, match="boolean"):
+        metadata.validate(metadata_classes=[rfc9101.AuthorizationServerMetadata])

--- a/tests/core/test_oauth2/test_rfc9207.py
+++ b/tests/core/test_oauth2/test_rfc9207.py
@@ -1,0 +1,45 @@
+import pytest
+
+from authlib.oauth2 import rfc8414
+from authlib.oauth2 import rfc9207
+
+
+def test_validate_authorization_response_iss_parameter_supported():
+    metadata = rfc9207.AuthorizationServerMetadata()
+    metadata.validate_authorization_response_iss_parameter_supported()
+
+    metadata = rfc9207.AuthorizationServerMetadata(
+        {"authorization_response_iss_parameter_supported": True}
+    )
+    metadata.validate_authorization_response_iss_parameter_supported()
+
+    metadata = rfc9207.AuthorizationServerMetadata(
+        {"authorization_response_iss_parameter_supported": False}
+    )
+    metadata.validate_authorization_response_iss_parameter_supported()
+
+    metadata = rfc9207.AuthorizationServerMetadata(
+        {"authorization_response_iss_parameter_supported": "invalid"}
+    )
+    with pytest.raises(ValueError, match="boolean"):
+        metadata.validate_authorization_response_iss_parameter_supported()
+
+
+def test_metadata_classes_composition():
+    base_metadata = {
+        "issuer": "https://provider.test",
+        "authorization_endpoint": "https://provider.test/auth",
+        "token_endpoint": "https://provider.test/token",
+        "response_types_supported": ["code"],
+    }
+
+    metadata = rfc8414.AuthorizationServerMetadata(
+        {**base_metadata, "authorization_response_iss_parameter_supported": True}
+    )
+    metadata.validate(metadata_classes=[rfc9207.AuthorizationServerMetadata])
+
+    metadata = rfc8414.AuthorizationServerMetadata(
+        {**base_metadata, "authorization_response_iss_parameter_supported": "invalid"}
+    )
+    with pytest.raises(ValueError, match="boolean"):
+        metadata.validate(metadata_classes=[rfc9207.AuthorizationServerMetadata])


### PR DESCRIPTION
Someday we should tackle #260 but in the meantime here is a way to compose a metadata object from all the bits in the different modules.