### PR TITLE
fix: remove "none" from default authlib.jose.jwt algorithms

### DIFF
--- a/authlib/jose/__init__.py
+++ b/authlib/jose/__init__.py
@@ -52,7 +52,24 @@ JsonWebKey.JWK_KEY_CLS = {
     OKPKey.kty: OKPKey,
 }
 
-jwt = JsonWebToken(list(JsonWebSignature.ALGORITHMS_REGISTRY.keys()))
+jwt = JsonWebToken(
+    [
+        "HS256",
+        "HS384",
+        "HS512",
+        "RS256",
+        "RS384",
+        "RS512",
+        "ES256",
+        "ES256K",
+        "ES384",
+        "ES512",
+        "PS256",
+        "PS384",
+        "PS512",
+        "EdDSA",
+    ]
+)
 
 
 __all__ = [


### PR DESCRIPTION
Remove `none` from default `jwt` for security concerns.