### PR TITLE
OpenID Connect Back-Channel Logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Generic, spec-compliant implementation to build clients and providers:
   - [x] OpenID Connect Discovery 1.0
   - [x] OpenID Connect Dynamic Client Registration 1.0
   - [x] [OpenID Connect RP-Initiated Logout 1.0](https://openid.net/specs/openid-connect-rpinitiated-1_0.html)
+  - [x] [OpenID Connect Back-Channel Logout 1.0](https://openid.net/specs/openid-connect-backchannel-1_0.html)
 
 Connect third party OAuth providers with Authlib built-in client integrations:
 

--- a/authlib/oauth2/rfc6749/authorization_server.py
+++ b/authlib/oauth2/rfc6749/authorization_server.py
@@ -156,6 +156,23 @@ class AuthorizationServer(Hookable):
     def register_extension(self, extension):
         self._extensions.append(extension(self))
 
+    def get_extension(self, cls):
+        """Retrieve a registered extension by class.
+
+        :param cls: The extension class to look up.
+        :returns: The extension instance, or ``None`` if not registered.
+
+        Example::
+
+            sender = server.get_extension(BackchannelLogoutExtension)
+            if sender:
+                sender.send_logout(sub=sub, sid=sid)
+        """
+        for ext in self._extensions:
+            if isinstance(ext, cls):
+                return ext
+        return None
+
     def get_error_uri(self, request, error):
         """Return a URI for the given error, framework may implement this method."""
         return None

--- a/authlib/oidc/backchannel/__init__.py
+++ b/authlib/oidc/backchannel/__init__.py
@@ -1,0 +1,21 @@
+"""authlib.oidc.backchannel.
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+OpenID Connect Back-Channel Logout 1.0 Implementation.
+
+https://openid.net/specs/openid-connect-backchannel-1_0.html
+"""
+
+from .discovery import OpenIDProviderMetadata
+from .logout_token import BACKCHANNEL_LOGOUT_EVENT
+from .logout_token import create_logout_token
+from .registration import ClientMetadataClaims
+from .sender import BackchannelLogoutExtension
+
+__all__ = [
+    "BackchannelLogoutExtension",
+    "ClientMetadataClaims",
+    "OpenIDProviderMetadata",
+    "create_logout_token",
+    "BACKCHANNEL_LOGOUT_EVENT",
+]

--- a/authlib/oidc/backchannel/discovery.py
+++ b/authlib/oidc/backchannel/discovery.py
@@ -1,0 +1,44 @@
+"""Provider metadata for OIDC Back-Channel Logout 1.0.
+
+https://openid.net/specs/openid-connect-backchannel-1_0.html
+"""
+
+
+class OpenIDProviderMetadata(dict):
+    """Provider metadata for OIDC Back-Channel Logout 1.0.
+
+    This can be used with :ref:`specs/rfc8414` discovery metadata::
+
+        from authlib.oidc import backchannel
+        from authlib.oidc import discovery
+
+        metadata = discovery.OpenIDProviderMetadata({
+            ...,
+            "backchannel_logout_supported": True,
+            "backchannel_logout_session_supported": True,
+        })
+        metadata.validate(metadata_classes=[backchannel.OpenIDProviderMetadata])
+    """
+
+    REGISTRY_KEYS = [
+        "backchannel_logout_supported",
+        "backchannel_logout_session_supported",
+    ]
+
+    def validate_backchannel_logout_supported(self):
+        # backchannel §2.1: "backchannel_logout_supported - OPTIONAL. Boolean value
+        # specifying whether the OP supports back-channel logout, with true indicating
+        # support. If omitted, the default value is false."
+        value = self.get("backchannel_logout_supported")
+        if value is not None and not isinstance(value, bool):
+            raise ValueError('"backchannel_logout_supported" MUST be a boolean')
+
+    def validate_backchannel_logout_session_supported(self):
+        # backchannel §2.1: "backchannel_logout_session_supported - OPTIONAL. Boolean
+        # value specifying whether the OP can pass a sid (session ID) Claim in the
+        # Logout Token to identify the RP session with the OP. If supported, the
+        # sid Claim is also included in ID Tokens issued by the OP. If omitted, the
+        # default value is false."
+        value = self.get("backchannel_logout_session_supported")
+        if value is not None and not isinstance(value, bool):
+            raise ValueError('"backchannel_logout_session_supported" MUST be a boolean')

--- a/authlib/oidc/backchannel/logout_token.py
+++ b/authlib/oidc/backchannel/logout_token.py
@@ -62,4 +62,4 @@ def create_logout_token(
     if isinstance(key, dict):
         key = KeySet.import_key_set(key)  # type: ignore[arg-type]
 
-    return jwt.encode(header, payload, key)
+    return jwt.encode(header, payload, key, algorithms=[algorithm])

--- a/authlib/oidc/backchannel/logout_token.py
+++ b/authlib/oidc/backchannel/logout_token.py
@@ -1,0 +1,65 @@
+"""Logout token creation for OIDC Back-Channel Logout 1.0.
+
+https://openid.net/specs/openid-connect-backchannel-1_0.html
+"""
+
+import time
+import uuid
+
+from joserfc import jwt
+from joserfc.jwk import KeySet
+
+BACKCHANNEL_LOGOUT_EVENT = "http://schemas.openid.net/event/backchannel-logout"
+
+
+def create_logout_token(
+    issuer: str,
+    audience: str,
+    key,
+    algorithm: str = "RS256",
+    sub: str | None = None,
+    sid: str | None = None,
+    expires_in: int = 120,
+) -> str:
+    """Create a signed logout token JWT.
+
+    :param issuer: The OP's issuer identifier.
+    :param audience: The client_id of the RP being notified.
+    :param key: The signing key (joserfc Key, KeySet, or JWKS dict).
+    :param algorithm: JWT signing algorithm.
+    :param sub: Subject identifier. Required if ``sid`` is not provided.
+    :param sid: Session ID. Required if ``sub`` is not provided.
+    :param expires_in: Token lifetime in seconds. Spec recommends at most 120.
+    :raises ValueError: If neither ``sub`` nor ``sid`` is provided.
+    """
+    # backchannel §2.4: "A Logout Token MUST contain either a sub or a sid
+    # Claim, and MAY contain both."
+    if sub is None and sid is None:
+        raise ValueError("At least one of 'sub' or 'sid' must be provided")
+
+    now = int(time.time())
+    payload: dict = {
+        "iss": issuer,
+        "aud": audience,
+        "iat": now,
+        "exp": now + expires_in,
+        "jti": str(uuid.uuid4()),
+        # backchannel §2.4: "events - [...] whose value is a JSON object
+        # containing the member name
+        # http://schemas.openid.net/event/backchannel-logout"
+        "events": {BACKCHANNEL_LOGOUT_EVENT: {}},
+    }
+
+    if sub is not None:
+        payload["sub"] = sub
+    if sid is not None:
+        payload["sid"] = sid
+
+    # backchannel §2.4: "The typ JOSE header parameter [...] SHOULD be
+    # logout+jwt"
+    header = {"alg": algorithm, "typ": "logout+jwt"}
+
+    if isinstance(key, dict):
+        key = KeySet.import_key_set(key)  # type: ignore[arg-type]
+
+    return jwt.encode(header, payload, key)

--- a/authlib/oidc/backchannel/logout_token.py
+++ b/authlib/oidc/backchannel/logout_token.py
@@ -8,6 +8,7 @@ import uuid
 
 from joserfc import jwt
 from joserfc.jwk import KeySet
+from joserfc.jwk import import_key
 
 BACKCHANNEL_LOGOUT_EVENT = "http://schemas.openid.net/event/backchannel-logout"
 
@@ -25,7 +26,7 @@ def create_logout_token(
 
     :param issuer: The OP's issuer identifier.
     :param audience: The client_id of the RP being notified.
-    :param key: The signing key (joserfc Key, KeySet, or JWKS dict).
+    :param key: The signing key (joserfc Key, KeySet, JWK dict, or JWKS dict).
     :param algorithm: JWT signing algorithm.
     :param sub: Subject identifier. Required if ``sid`` is not provided.
     :param sid: Session ID. Required if ``sub`` is not provided.
@@ -60,6 +61,9 @@ def create_logout_token(
     header = {"alg": algorithm, "typ": "logout+jwt"}
 
     if isinstance(key, dict):
-        key = KeySet.import_key_set(key)  # type: ignore[arg-type]
+        if "keys" in key:
+            key = KeySet.import_key_set(key)  # type: ignore[arg-type]
+        else:
+            key = import_key(key)
 
     return jwt.encode(header, payload, key, algorithms=[algorithm])

--- a/authlib/oidc/backchannel/registration.py
+++ b/authlib/oidc/backchannel/registration.py
@@ -1,0 +1,62 @@
+"""Client metadata for OIDC Back-Channel Logout 1.0.
+
+https://openid.net/specs/openid-connect-backchannel-1_0.html
+"""
+
+from joserfc.errors import InvalidClaimError
+
+from authlib.common.security import is_secure_transport
+from authlib.common.urls import is_valid_url
+from authlib.oauth2.claims import BaseClaims
+
+
+class ClientMetadataClaims(BaseClaims):
+    """Client metadata for OIDC Back-Channel Logout 1.0.
+
+    This can be used with :ref:`specs/rfc7591` and :ref:`specs/rfc7592` endpoints::
+
+        server.register_endpoint(
+            ClientRegistrationEndpoint(
+                claims_classes=[
+                    rfc7591.ClientMetadataClaims,
+                    oidc.registration.ClientMetadataClaims,
+                    oidc.backchannel.ClientMetadataClaims,
+                ]
+            )
+        )
+    """
+
+    REGISTERED_CLAIMS = [
+        "backchannel_logout_uri",
+        "backchannel_logout_session_required",
+    ]
+
+    def validate(self, now=None, leeway=0):
+        super().validate(now, leeway)
+        self._validate_backchannel_logout_uri()
+        self._validate_backchannel_logout_session_required()
+
+    def _validate_backchannel_logout_uri(self):
+        # backchannel §2.2: "backchannel_logout_uri - OPTIONAL. RP URL that will
+        # cause the RP to log itself out when sent a Logout Token by the OP. This
+        # URL MUST use the https scheme and MAY contain port, path, and query
+        # parameter components; it MUST NOT contain a fragment component."
+        uri = self.get("backchannel_logout_uri")
+        if not uri:
+            return
+
+        if not is_valid_url(uri, fragments_allowed=False):
+            raise InvalidClaimError("backchannel_logout_uri")
+
+        if not is_secure_transport(uri):
+            raise ValueError('"backchannel_logout_uri" MUST use "https" scheme')
+
+    def _validate_backchannel_logout_session_required(self):
+        # backchannel §2.2: "backchannel_logout_session_required - OPTIONAL.
+        # Boolean value specifying whether the RP requires that a sid (session ID)
+        # Claim be included in the Logout Token to identify the RP session with
+        # the OP when the backchannel_logout_uri is used. If omitted, the default
+        # value is false."
+        value = self.get("backchannel_logout_session_required")
+        if value is not None and not isinstance(value, bool):
+            raise InvalidClaimError("backchannel_logout_session_required")

--- a/authlib/oidc/backchannel/sender.py
+++ b/authlib/oidc/backchannel/sender.py
@@ -1,0 +1,142 @@
+"""Back-channel logout notification sender for OIDC Back-Channel Logout 1.0.
+
+https://openid.net/specs/openid-connect-backchannel-1_0.html
+"""
+
+from .logout_token import create_logout_token
+
+
+class BackchannelLogoutExtension:
+    """Authorization server extension that sends back-channel logout notifications.
+
+    Register it once on the authorization server::
+
+        class MyBackchannelLogoutExtension(BackchannelLogoutExtension):
+            def get_issuer(self):
+                return "https://auth.example.com"
+
+            def get_signing_key(self):
+                return load_private_jwks()
+
+            def get_logout_clients(self, sub, sid):
+                return db.query_active_clients(sub=sub, sid=sid)
+
+            def deliver_logout_token(self, client, uri, logout_token):
+                requests.post(uri, data={"logout_token": logout_token}, timeout=5)
+
+
+        server.register_extension(MyBackchannelLogoutExtension())
+
+    Then call it from anywhere a session ends::
+
+        server.get_extension(BackchannelLogoutExtension).send_logout(sub=sub, sid=sid)
+
+    Each client object returned by :meth:`get_logout_clients` is expected to be
+    a :class:`~authlib.oauth2.rfc6749.models.ClientMixin` instance. The sender
+    accesses ``client.client_id`` and ``client.client_metadata``, which are the
+    standard attributes exposed by all authlib client model implementations.
+
+    The ``client_metadata`` dict must contain:
+
+    - ``backchannel_logout_uri`` — the RP's back-channel logout endpoint
+    - ``backchannel_logout_session_required`` — whether the RP requires ``sid``
+      (default: ``False``)
+    """
+
+    def __call__(self, server):
+        return self
+
+    def send_logout(self, sub: str | None = None, sid: str | None = None) -> None:
+        """Notify all relevant RPs that the user session has ended.
+
+        :param sub: Subject identifier of the logged-out user.
+        :param sid: Session ID of the terminated session.
+        """
+        clients = self.get_logout_clients(sub, sid)
+        issuer = self.get_issuer()
+        key = self.get_signing_key()
+        algorithm = self.get_signing_algorithm()
+
+        for client in clients:
+            metadata = client.client_metadata
+            uri = metadata.get("backchannel_logout_uri")
+            if not uri:
+                continue
+
+            # backchannel §2.6: "If the Logout Token contains a sid Claim,
+            # its value MUST identify the RP session with the OP that is being
+            # logged out. If the RP requires the sid Claim in the Logout Token,
+            # it MUST register this requirement by including
+            # backchannel_logout_session_required as a registered Client
+            # Metadata value set to true."
+            session_required = metadata.get(
+                "backchannel_logout_session_required", False
+            )
+            if session_required and sid is None:
+                continue
+
+            token = create_logout_token(
+                issuer=issuer,
+                audience=client.client_id,
+                key=key,
+                algorithm=algorithm,
+                sub=sub,
+                sid=sid,
+            )
+            self.deliver_logout_token(client, uri, token)
+
+    # --- Abstract methods ---
+
+    def get_issuer(self) -> str:
+        """Return the OP's issuer identifier (e.g. ``'https://auth.example.com'``)."""
+        raise NotImplementedError()
+
+    def get_signing_key(self):
+        """Return the private signing key (joserfc ``Key``, ``KeySet``, or JWKS dict)."""
+        raise NotImplementedError()
+
+    def get_logout_clients(self, sub: str | None, sid: str | None) -> list:
+        """Return the clients to notify for this session/user.
+
+        Each returned object is expected to be a
+        :class:`~authlib.oauth2.rfc6749.models.ClientMixin` instance, exposing
+        ``client_id`` and ``client_metadata`` attributes. Clients without a
+        ``backchannel_logout_uri`` in their metadata are silently skipped.
+
+        Return only clients with an active session for the given identifiers —
+        not all registered clients. If ``sid`` is provided, return the single
+        client associated with that session. If only ``sub`` is provided, return
+        all clients with an active session for that user::
+
+            def get_logout_clients(self, sub, sid):
+                if sid:
+                    sessions = db.query(OIDCSession).filter_by(sid=sid).all()
+                else:
+                    sessions = db.query(OIDCSession).filter_by(sub=sub).all()
+                return [s.client for s in sessions]
+        """
+        raise NotImplementedError()
+
+    def deliver_logout_token(self, client, uri: str, logout_token: str) -> None:
+        """Send the logout token to ``uri`` via HTTP POST.
+
+        The request body must be ``application/x-www-form-urlencoded`` with a
+        single ``logout_token`` parameter. The spec expects ``200`` or ``204``
+        on success, ``400`` on error::
+
+            def deliver_logout_token(self, client, uri, logout_token):
+                try:
+                    resp = requests.post(
+                        uri, data={"logout_token": logout_token}, timeout=5
+                    )
+                    resp.raise_for_status()
+                except requests.RequestException as e:
+                    logger.warning("Backchannel logout failed for %s: %s", uri, e)
+        """
+        raise NotImplementedError()
+
+    # --- Overridable ---
+
+    def get_signing_algorithm(self) -> str:
+        """Return the JWT signing algorithm. Defaults to ``'RS256'``."""
+        return "RS256"

--- a/docs/oauth2/specs/backchannel.rst
+++ b/docs/oauth2/specs/backchannel.rst
@@ -1,0 +1,241 @@
+.. _specs/backchannel:
+
+OpenID Connect Back-Channel Logout 1.0
+=======================================
+
+.. meta::
+    :description: Python API references on OpenID Connect Back-Channel Logout 1.0
+        with Authlib implementation.
+
+.. module:: authlib.oidc.backchannel
+
+This section contains the generic implementation of `OpenID Connect Back-Channel
+Logout 1.0`_. This specification enables an OpenID Provider (OP) to notify
+Relying Parties (RPs) of session termination via direct server-to-server HTTP
+requests, without requiring any browser involvement.
+
+.. _OpenID Connect Back-Channel Logout 1.0: https://openid.net/specs/openid-connect-backchannel-1_0.html
+
+Overview
+--------
+
+When a user's session ends at the OP (for any reason — RP-initiated logout,
+admin action, token expiry, etc.), the OP sends a signed **logout token** via
+POST to each RP's registered ``backchannel_logout_uri``.
+
+The logout token is a JWT carrying the subject (``sub``) and/or session ID
+(``sid``) of the terminated session, allowing each RP to identify and destroy
+the corresponding local session.
+
+Sending Logout Notifications
+-----------------------------
+
+:class:`BackchannelLogoutExtension` is an authorization server extension. Register
+it once, then retrieve it anywhere via
+:meth:`~authlib.oauth2.rfc6749.AuthorizationServer.get_extension`::
+
+    from authlib.oidc.backchannel import BackchannelLogoutExtension
+
+    class MyBackchannelLogoutExtension(BackchannelLogoutExtension):
+
+        def get_issuer(self):
+            return "https://auth.example.com"
+
+        def get_signing_key(self):
+            # Return a joserfc Key, KeySet, or JWKS dict (private key required)
+            return load_private_jwks()
+
+        def get_logout_clients(self, sub, sid):
+            # Return all clients that have an active session for this user/session.
+            # Each object must expose:
+            #   - client_id (str)
+            #   - client_metadata (dict) with 'backchannel_logout_uri' and
+            #     optionally 'backchannel_logout_session_required'
+            return db.query_clients_for_session(sub=sub, sid=sid)
+
+        def deliver_logout_token(self, client, uri, logout_token):
+            # Perform the HTTP POST. Choose your own library and error handling.
+            import requests
+            requests.post(uri, data={"logout_token": logout_token}, timeout=5)
+
+
+    server.register_extension(MyBackchannelLogoutExtension())
+
+Then call :meth:`~BackchannelLogoutExtension.send_logout` from anywhere a session
+ends — an endpoint, an admin view, a background task::
+
+    server.get_extension(BackchannelLogoutExtension).send_logout(sub="user-123", sid="sess-abc")
+
+:meth:`~BackchannelLogoutExtension.send_logout` takes care of:
+
+- skipping clients that have no ``backchannel_logout_uri``
+- skipping clients that require a ``sid`` when none is available
+- generating a unique, signed logout token per client
+
+Integration with RP-Initiated Logout
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A common pattern is to trigger backchannel logout from
+:class:`~authlib.oidc.rpinitiated.EndSessionEndpoint`::
+
+    from authlib.oidc.backchannel import BackchannelLogoutExtension
+    from authlib.oidc.rpinitiated import EndSessionEndpoint
+
+    class MyEndSessionEndpoint(EndSessionEndpoint):
+
+        def end_session(self, end_session_request):
+            claims = end_session_request.id_token_claims or {}
+            self.server.get_extension(BackchannelLogoutExtension).send_logout(
+                sub=claims.get("sub"),
+                sid=claims.get("sid"),
+            )
+            session.clear()
+
+        def get_server_jwks(self):
+            return load_public_jwks()
+
+Session Tracking
+~~~~~~~~~~~~~~~~
+
+To avoid notifying every registered client on each logout,
+:meth:`~BackchannelLogoutExtension.get_logout_clients` should return only the
+clients that have an active session for the given user or session ID. Implement
+it to query whatever session store your application maintains (e.g. a table of
+active ``(user, client)`` pairs keyed by ``sid``).
+
+The ``sid`` (session ID) is established at authentication time and included as a
+claim in the ID Token issued to the RP. The RP therefore knows its ``sid`` from
+the moment the session is created, and can use it to match an incoming logout
+token to the correct local session.
+
+The ``sub`` and ``sid`` parameters are both optional so that ``send_logout`` can
+be called with whichever identifiers are available::
+
+    sender = server.get_extension(BackchannelLogoutExtension)
+
+    # Logout by subject only (all sessions for this user)
+    sender.send_logout(sub="user-123")
+
+    # Logout a specific session
+    sender.send_logout(sub="user-123", sid="sess-abc")
+
+    # Session-only logout (when sub is not available)
+    sender.send_logout(sid="sess-abc")
+
+HTTP Delivery
+~~~~~~~~~~~~~
+
+The spec requires a ``POST`` request with ``Content-Type: application/x-www-form-urlencoded``
+and a single ``logout_token`` parameter. The OP SHOULD attempt parallel delivery
+to multiple RPs and MAY retry on failure. Implement this in
+:meth:`~BackchannelLogoutExtension.deliver_logout_token`::
+
+    def deliver_logout_token(self, client, uri, logout_token):
+        import requests
+        try:
+            resp = requests.post(
+                uri,
+                data={"logout_token": logout_token},
+                timeout=5,
+            )
+            resp.raise_for_status()
+        except requests.RequestException:
+            # Log the failure; decide on retry policy
+            logger.warning("Failed to deliver logout to %s", uri)
+
+Logout Token
+------------
+
+Logout tokens are generated automatically by :meth:`~BackchannelLogoutExtension.send_logout`.
+You can also create them directly with :func:`create_logout_token` if needed::
+
+    from authlib.oidc.backchannel import create_logout_token
+
+    token = create_logout_token(
+        issuer="https://auth.example.com",
+        audience="client-id",
+        key=private_key,
+        sub="user-123",
+        sid="sess-abc",
+        expires_in=120,  # spec recommends at most 120 seconds
+    )
+
+The logout token is a JWT with the following claims:
+
+- **iss** — issuer identifier
+- **aud** — the client being notified
+- **iat** — issued-at timestamp
+- **exp** — expiration timestamp
+- **jti** — unique token ID (auto-generated, for replay prevention)
+- **events** — object containing the ``http://schemas.openid.net/event/backchannel-logout`` member
+- **sub** and/or **sid** — at least one is required
+
+The ``nonce`` claim is explicitly forbidden by the specification.
+
+Client Registration
+-------------------
+
+Relying Parties register their back-channel logout endpoint via
+:ref:`RFC7591: OAuth 2.0 Dynamic Client Registration Protocol <specs/rfc7591>`.
+
+To support back-channel logout client metadata, add the claims class to your
+registration and configuration endpoints::
+
+    from authlib import oidc
+    from authlib.oauth2 import rfc7591
+
+    authorization_server.register_endpoint(
+        ClientRegistrationEndpoint(
+            claims_classes=[
+                rfc7591.ClientMetadataClaims,
+                oidc.registration.ClientMetadataClaims,
+                oidc.backchannel.ClientMetadataClaims,
+            ]
+        )
+    )
+
+The following client metadata parameters are supported:
+
+- **backchannel_logout_uri** — The RP's back-channel logout endpoint. Must use
+  ``https`` (``http`` is allowed for ``localhost``). Must not contain a fragment.
+- **backchannel_logout_session_required** — Boolean. When ``True``, the OP will
+  only send a logout token to this client if a ``sid`` is available. Defaults to
+  ``False``.
+
+Discovery
+---------
+
+To advertise back-channel logout support in your OpenID Provider metadata, add
+the discovery class to your metadata validation::
+
+    from authlib.oidc import backchannel
+    from authlib.oidc import discovery
+
+    metadata = discovery.OpenIDProviderMetadata({
+        ...,
+        "backchannel_logout_supported": True,
+        "backchannel_logout_session_supported": True,
+    })
+    metadata.validate(metadata_classes=[backchannel.OpenIDProviderMetadata])
+
+- **backchannel_logout_supported** — Boolean. Whether the OP supports back-channel
+  logout. Defaults to ``False``.
+- **backchannel_logout_session_supported** — Boolean. Whether the OP can include a
+  ``sid`` claim in logout tokens. Defaults to ``False``.
+
+API Reference
+-------------
+
+.. autoclass:: BackchannelLogoutExtension
+    :member-order: bysource
+    :members:
+
+.. autofunction:: create_logout_token
+
+.. autoclass:: ClientMetadataClaims
+    :member-order: bysource
+    :members:
+
+.. autoclass:: OpenIDProviderMetadata
+    :member-order: bysource
+    :members:

--- a/docs/oauth2/specs/index.rst
+++ b/docs/oauth2/specs/index.rst
@@ -19,3 +19,4 @@ Specifications
     rfc9207
     oidc
     rpinitiated
+    backchannel

--- a/docs/upgrades/changelog.rst
+++ b/docs/upgrades/changelog.rst
@@ -11,6 +11,9 @@ Version 1.7.0
 
 **Unreleased**
 
+- Add support for `OpenID Connect Back-Channel Logout 1.0
+  <https://openid.net/specs/openid-connect-backchannel-1_0.html>`_.
+  See :ref:`specs/backchannel` for details.
 - Add support for `OpenID Connect RP-Initiated Logout 1.0
   <https://openid.net/specs/openid-connect-rpinitiated-1_0.html>`_.
   See :ref:`specs/rpinitiated` for details. :issue:`500`

--- a/tests/core/test_oidc/test_backchannel.py
+++ b/tests/core/test_oidc/test_backchannel.py
@@ -1,0 +1,373 @@
+"""Tests for OIDC Back-Channel Logout 1.0."""
+
+import time
+
+import pytest
+from joserfc import jwt
+from joserfc.errors import InvalidClaimError
+from joserfc.jwk import KeySet
+
+from authlib.oauth2.rfc6749 import AuthorizationServer
+from authlib.oidc import backchannel
+from authlib.oidc import discovery
+from authlib.oidc.backchannel import BACKCHANNEL_LOGOUT_EVENT
+from authlib.oidc.backchannel import BackchannelLogoutExtension
+from authlib.oidc.backchannel import ClientMetadataClaims
+from authlib.oidc.backchannel import create_logout_token
+from tests.util import read_file_path
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+ISSUER = "https://provider.test"
+CLIENT_ID = "client-1"
+
+
+def get_private_jwks():
+    return KeySet.import_key_set(read_file_path("jwks_private.json"))
+
+
+def decode_token(token):
+    jwks = KeySet.import_key_set(read_file_path("jwks_public.json"))
+    return jwt.decode(token, jwks)
+
+
+class FakeClient:
+    def __init__(self, client_id, backchannel_logout_uri=None, session_required=False):
+        self.client_id = client_id
+        self.client_metadata = {
+            "backchannel_logout_uri": backchannel_logout_uri,
+            "backchannel_logout_session_required": session_required,
+        }
+
+
+class CollectingSender(BackchannelLogoutExtension):
+    """Test sender that collects delivered tokens instead of sending HTTP."""
+
+    def __init__(self, clients):
+        self._clients = clients
+        self.delivered = []
+
+    def get_issuer(self):
+        return ISSUER
+
+    def get_signing_key(self):
+        return get_private_jwks()
+
+    def get_logout_clients(self, sub, sid):
+        return self._clients
+
+    def deliver_logout_token(self, client, uri, logout_token):
+        self.delivered.append((client, uri, logout_token))
+
+
+# ---------------------------------------------------------------------------
+# create_logout_token
+# ---------------------------------------------------------------------------
+
+
+def test_create_logout_token_with_sub():
+    token = create_logout_token(ISSUER, CLIENT_ID, get_private_jwks(), sub="user-1")
+    decoded = decode_token(token)
+    claims = decoded.claims
+
+    assert claims["iss"] == ISSUER
+    assert claims["aud"] == CLIENT_ID
+    assert claims["sub"] == "user-1"
+    assert "sid" not in claims
+    assert BACKCHANNEL_LOGOUT_EVENT in claims["events"]
+    assert "jti" in claims
+    assert "iat" in claims
+    assert "exp" in claims
+    assert decoded.header["typ"] == "logout+jwt"
+
+
+def test_create_logout_token_with_sid():
+    token = create_logout_token(ISSUER, CLIENT_ID, get_private_jwks(), sid="sess-abc")
+    claims = decode_token(token).claims
+
+    assert claims["sid"] == "sess-abc"
+    assert "sub" not in claims
+
+
+def test_create_logout_token_with_both():
+    token = create_logout_token(
+        ISSUER, CLIENT_ID, get_private_jwks(), sub="user-1", sid="sess-abc"
+    )
+    claims = decode_token(token).claims
+
+    assert claims["sub"] == "user-1"
+    assert claims["sid"] == "sess-abc"
+
+
+def test_create_logout_token_neither_sub_nor_sid_raises():
+    with pytest.raises(ValueError, match="sub.*sid|sid.*sub"):
+        create_logout_token(ISSUER, CLIENT_ID, get_private_jwks())
+
+
+def test_create_logout_token_nonce_not_present():
+    token = create_logout_token(ISSUER, CLIENT_ID, get_private_jwks(), sub="user-1")
+    assert "nonce" not in decode_token(token).claims
+
+
+def test_create_logout_token_expiry():
+    before = int(time.time())
+    token = create_logout_token(
+        ISSUER, CLIENT_ID, get_private_jwks(), sub="user-1", expires_in=60
+    )
+    after = int(time.time())
+    claims = decode_token(token).claims
+
+    assert claims["exp"] - claims["iat"] == 60
+    assert before <= claims["iat"] <= after
+
+
+def test_create_logout_token_accepts_jwks_dict():
+    jwks_dict = read_file_path("jwks_private.json")
+    token = create_logout_token(ISSUER, CLIENT_ID, jwks_dict, sub="user-1")
+    claims = decode_token(token).claims
+    assert claims["iss"] == ISSUER
+
+
+def test_create_logout_token_unique_jti():
+    t1 = create_logout_token(ISSUER, CLIENT_ID, get_private_jwks(), sub="user-1")
+    t2 = create_logout_token(ISSUER, CLIENT_ID, get_private_jwks(), sub="user-1")
+    assert decode_token(t1).claims["jti"] != decode_token(t2).claims["jti"]
+
+
+# ---------------------------------------------------------------------------
+# BackchannelLogoutExtension — extension registration
+# ---------------------------------------------------------------------------
+
+
+class MinimalServer(AuthorizationServer):
+    """Minimal server for testing extension registration."""
+
+    def query_client(self, client_id):
+        raise NotImplementedError()
+
+    def save_token(self, token, request):
+        raise NotImplementedError()
+
+    def send_signal(self, name, *args, **kwargs):
+        raise NotImplementedError()
+
+    def create_oauth2_request(self, request):
+        raise NotImplementedError()
+
+    def create_json_request(self, request):
+        raise NotImplementedError()
+
+    def handle_response(self, status, body, headers):
+        raise NotImplementedError()
+
+
+def test_get_extension_returns_sender():
+    server = MinimalServer()
+    sender = CollectingSender([])
+    server.register_extension(sender)
+    assert server.get_extension(BackchannelLogoutExtension) is sender
+
+
+def test_get_extension_returns_none_when_not_registered():
+    server = MinimalServer()
+    assert server.get_extension(BackchannelLogoutExtension) is None
+
+
+def test_get_extension_and_send_logout():
+    client = FakeClient(CLIENT_ID, backchannel_logout_uri="https://rp.test/logout")
+    sender = CollectingSender([client])
+    server = MinimalServer()
+    server.register_extension(sender)
+
+    server.get_extension(BackchannelLogoutExtension).send_logout(sub="user-1")
+
+    assert len(sender.delivered) == 1
+    assert decode_token(sender.delivered[0][2]).claims["sub"] == "user-1"
+
+
+# ---------------------------------------------------------------------------
+# BackchannelLogoutExtension — send_logout behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_sender_delivers_to_registered_clients():
+    client = FakeClient(CLIENT_ID, backchannel_logout_uri="https://rp.test/logout")
+    sender = CollectingSender([client])
+    sender.send_logout(sub="user-1")
+
+    assert len(sender.delivered) == 1
+    delivered_client, uri, token = sender.delivered[0]
+    assert delivered_client is client
+    assert uri == "https://rp.test/logout"
+    claims = decode_token(token).claims
+    assert claims["aud"] == CLIENT_ID
+    assert claims["sub"] == "user-1"
+
+
+def test_sender_skips_clients_without_logout_uri():
+    client = FakeClient(CLIENT_ID, backchannel_logout_uri=None)
+    sender = CollectingSender([client])
+    sender.send_logout(sub="user-1")
+
+    assert sender.delivered == []
+
+
+def test_sender_skips_session_required_client_when_no_sid():
+    client = FakeClient(
+        CLIENT_ID,
+        backchannel_logout_uri="https://rp.test/logout",
+        session_required=True,
+    )
+    sender = CollectingSender([client])
+    sender.send_logout(sub="user-1", sid=None)
+
+    assert sender.delivered == []
+
+
+def test_sender_delivers_to_session_required_client_when_sid_provided():
+    client = FakeClient(
+        CLIENT_ID,
+        backchannel_logout_uri="https://rp.test/logout",
+        session_required=True,
+    )
+    sender = CollectingSender([client])
+    sender.send_logout(sub="user-1", sid="sess-abc")
+
+    assert len(sender.delivered) == 1
+    claims = decode_token(sender.delivered[0][2]).claims
+    assert claims["sid"] == "sess-abc"
+
+
+def test_sender_notifies_multiple_clients():
+    clients = [
+        FakeClient("rp-1", backchannel_logout_uri="https://rp1.test/logout"),
+        FakeClient("rp-2", backchannel_logout_uri="https://rp2.test/logout"),
+        FakeClient("rp-3", backchannel_logout_uri=None),
+    ]
+    sender = CollectingSender(clients)
+    sender.send_logout(sub="user-1")
+
+    assert len(sender.delivered) == 2
+    audiences = {decode_token(token).claims["aud"] for _, _, token in sender.delivered}
+    assert audiences == {"rp-1", "rp-2"}
+
+
+def test_sender_passes_sid_to_token():
+    client = FakeClient(CLIENT_ID, backchannel_logout_uri="https://rp.test/logout")
+    sender = CollectingSender([client])
+    sender.send_logout(sub="user-1", sid="sess-xyz")
+
+    claims = decode_token(sender.delivered[0][2]).claims
+    assert claims["sub"] == "user-1"
+    assert claims["sid"] == "sess-xyz"
+
+
+# ---------------------------------------------------------------------------
+# ClientMetadataClaims (registration)
+# ---------------------------------------------------------------------------
+
+
+def test_backchannel_logout_uri_valid():
+    claims = ClientMetadataClaims(
+        {"backchannel_logout_uri": "https://rp.test/backchannel_logout"}, {}
+    )
+    claims.validate()
+
+
+def test_backchannel_logout_uri_missing_is_valid():
+    claims = ClientMetadataClaims({}, {})
+    claims.validate()
+
+
+def test_backchannel_logout_uri_invalid_url():
+    claims = ClientMetadataClaims({"backchannel_logout_uri": "not-a-url"}, {})
+    with pytest.raises(InvalidClaimError):
+        claims.validate()
+
+
+def test_backchannel_logout_uri_with_fragment_rejected():
+    claims = ClientMetadataClaims(
+        {"backchannel_logout_uri": "https://rp.test/logout#section"}, {}
+    )
+    with pytest.raises(InvalidClaimError):
+        claims.validate()
+
+
+def test_backchannel_logout_uri_insecure():
+    claims = ClientMetadataClaims(
+        {"backchannel_logout_uri": "http://rp.test/logout"}, {}
+    )
+    with pytest.raises(ValueError, match="https"):
+        claims.validate()
+
+
+def test_backchannel_logout_uri_localhost_allowed():
+    claims = ClientMetadataClaims(
+        {"backchannel_logout_uri": "http://localhost:8080/logout"}, {}
+    )
+    claims.validate()
+
+
+def test_backchannel_logout_session_required_valid():
+    claims = ClientMetadataClaims(
+        {
+            "backchannel_logout_uri": "https://rp.test/logout",
+            "backchannel_logout_session_required": True,
+        },
+        {},
+    )
+    claims.validate()
+
+
+def test_backchannel_logout_session_required_invalid_type():
+    claims = ClientMetadataClaims({"backchannel_logout_session_required": "yes"}, {})
+    with pytest.raises(InvalidClaimError):
+        claims.validate()
+
+
+# ---------------------------------------------------------------------------
+# OpenIDProviderMetadata (discovery)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def valid_oidc_metadata():
+    return {
+        "issuer": "https://provider.test",
+        "authorization_endpoint": "https://provider.test/authorize",
+        "token_endpoint": "https://provider.test/token",
+        "jwks_uri": "https://provider.test/jwks.json",
+        "response_types_supported": ["code"],
+        "subject_types_supported": ["public"],
+        "id_token_signing_alg_values_supported": ["RS256"],
+    }
+
+
+def test_discovery_backchannel_logout_supported(valid_oidc_metadata):
+    valid_oidc_metadata["backchannel_logout_supported"] = True
+    valid_oidc_metadata["backchannel_logout_session_supported"] = True
+    metadata = discovery.OpenIDProviderMetadata(valid_oidc_metadata)
+    metadata.validate(metadata_classes=[backchannel.OpenIDProviderMetadata])
+
+
+def test_discovery_backchannel_fields_optional(valid_oidc_metadata):
+    metadata = discovery.OpenIDProviderMetadata(valid_oidc_metadata)
+    metadata.validate(metadata_classes=[backchannel.OpenIDProviderMetadata])
+
+
+def test_discovery_backchannel_logout_supported_invalid_type(valid_oidc_metadata):
+    valid_oidc_metadata["backchannel_logout_supported"] = "true"
+    metadata = discovery.OpenIDProviderMetadata(valid_oidc_metadata)
+    with pytest.raises(ValueError, match="boolean"):
+        metadata.validate(metadata_classes=[backchannel.OpenIDProviderMetadata])
+
+
+def test_discovery_backchannel_logout_session_supported_invalid_type(
+    valid_oidc_metadata,
+):
+    valid_oidc_metadata["backchannel_logout_session_supported"] = "true"
+    metadata = discovery.OpenIDProviderMetadata(valid_oidc_metadata)
+    with pytest.raises(ValueError, match="boolean"):
+        metadata.validate(metadata_classes=[backchannel.OpenIDProviderMetadata])

--- a/tests/core/test_oidc/test_backchannel.py
+++ b/tests/core/test_oidc/test_backchannel.py
@@ -6,6 +6,7 @@ import pytest
 from joserfc import jwt
 from joserfc.errors import InvalidClaimError
 from joserfc.jwk import KeySet
+from joserfc.jwk import import_key
 
 from authlib.oauth2.rfc6749 import AuthorizationServer
 from authlib.oidc import backchannel
@@ -128,6 +129,15 @@ def test_create_logout_token_accepts_jwks_dict():
     token = create_logout_token(ISSUER, CLIENT_ID, jwks_dict, sub="user-1")
     claims = decode_token(token).claims
     assert claims["iss"] == ISSUER
+
+
+def test_create_logout_token_accepts_jwk_dict():
+    """A single JWK passed as a dict is accepted as the signing key."""
+    jwk_dict = read_file_path("jwks_private.json")["keys"][0]
+    token = create_logout_token(ISSUER, CLIENT_ID, jwk_dict, sub="user-1")
+    claims = jwt.decode(token, import_key(jwk_dict)).claims
+    assert claims["iss"] == ISSUER
+    assert claims["sub"] == "user-1"
 
 
 def test_create_logout_token_unique_jti():


### PR DESCRIPTION
This PR implements [OpenID Connect Back-Channel Logout](https://openid.net/specs/openid-connect-backchannel-1_0.html).

- New AS extension `BackchannelLogoutExtension`
- New `AuthorizationServer.get_extension` method to access it with `server.get_extension(BackchannelLogoutSender)`
- `BackchannelLogoutExtension.send_logout` sends the logout JWT to all the matching clients.

fixes #560

**Checklist**

- [x] The commits follow the [conventional commits](https://www.conventionalcommits.org) specification.
- [x] You ran the linters with ``prek``.
- [x] You wrote unit test to demonstrate the bug you are fixing, or to stress the feature you are bringing.
- [x] You reached 100% of code coverage on the code you edited, without abusive use of `pragma: no cover`
- [x] If this PR is about a new feature, or a behavior change, you have updated the documentation accordingly.
- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
