### PR TITLE
Fix RFC7523 signing with non RSA keys

### DIFF
--- a/authlib/oauth2/rfc7523/auth.py
+++ b/authlib/oauth2/rfc7523/auth.py
@@ -1,4 +1,6 @@
 from joserfc.jwk import OctKey
+from joserfc.jwk import ECKey
+from joserfc.jwk import OKPKey
 
 from authlib.common.urls import add_params_to_qs
 
@@ -99,8 +101,12 @@ class PrivateKeyJWT(ClientSecretJWT):
     alg = "RS256"
 
     def sign(self, auth, token_endpoint):
+        if isinstance(auth.client_secret, (RSAKey, ECKey, OKPKey)):
+            key = auth.client_secret
+        else:
+            key = RSAKey.import_key(auth.client_secret)
         return private_key_jwt_sign(
-            auth.client_secret,
+            key,
             client_id=auth.client_id,
             token_endpoint=token_endpoint,
             claims=self.claims,

--- a/authlib/oauth2/rfc7523/auth.py
+++ b/authlib/oauth2/rfc7523/auth.py
@@ -1,4 +1,5 @@
 from joserfc.jwk import OctKey
+from joserfc.jwk import RSAKey
 from joserfc.jwk import ECKey
 from joserfc.jwk import OKPKey
 

--- a/authlib/oauth2/rfc7523/auth.py
+++ b/authlib/oauth2/rfc7523/auth.py
@@ -1,5 +1,4 @@
 from joserfc.jwk import OctKey
-from joserfc.jwk import RSAKey
 
 from authlib.common.urls import add_params_to_qs
 
@@ -100,12 +99,8 @@ class PrivateKeyJWT(ClientSecretJWT):
     alg = "RS256"
 
     def sign(self, auth, token_endpoint):
-        if isinstance(auth.client_secret, RSAKey):
-            key = auth.client_secret
-        else:
-            key = RSAKey.import_key(auth.client_secret)
         return private_key_jwt_sign(
-            key,
+            auth.client_secret,
             client_id=auth.client_id,
             token_endpoint=token_endpoint,
             claims=self.claims,

--- a/docs/upgrades/changelog.rst
+++ b/docs/upgrades/changelog.rst
@@ -6,6 +6,15 @@ Changelog
 
 Here you can see the full list of changes between each Authlib release.
 
+Version 1.7.2
+-------------
+
+**Unreleased**
+
+- Fix ``PrivateKeyJWT`` rejecting ``ECKey`` private keys (e.g. for ``ES256``).
+  The client private key is no longer forcibly imported as an ``RSAKey``;
+  ``joserfc``'s key auto-detection is used instead. :pr:`852`
+
 Version 1.7.1
 -------------
 

--- a/tests/core/test_oauth2/test_rfc7523_private_key.py
+++ b/tests/core/test_oauth2/test_rfc7523_private_key.py
@@ -1,7 +1,9 @@
 import time
+from types import SimpleNamespace
 from unittest import mock
 
 from joserfc import jwt
+from joserfc.jwk import ECKey
 from joserfc.jwk import RSAKey
 
 from authlib.oauth2.rfc7523 import PrivateKeyJWT
@@ -229,3 +231,18 @@ def test_sign_with_additional_claims():
         "role": "bar",
     }
     assert {"alg": "RS256", "typ": "JWT"} == decoded.header
+
+
+def test_sign_with_ec_key():
+    """``PrivateKeyJWT`` should accept an ``ECKey`` private key and sign with ES256."""
+    ec_key = ECKey.generate_key("P-256", private=True)
+    jwt_signer = PrivateKeyJWT(alg="ES256")
+    auth = SimpleNamespace(client_id="client_id_1", client_secret=ec_key)
+
+    data = jwt_signer.sign(auth, "https://provider.test/oauth/access_token")
+    decoded = jwt.decode(data, ec_key)
+
+    assert decoded.claims["iss"] == "client_id_1"
+    assert decoded.claims["sub"] == "client_id_1"
+    assert decoded.claims["aud"] == "https://provider.test/oauth/access_token"
+    assert decoded.header["alg"] == "ES256"


### PR DESCRIPTION
Partially fix the issue raised [by this comment](https://github.com/authlib/authlib/pull/852/changes/BASE..fb2501e2714820eb7bfaaaf3210dbad0b612a799#r3182703972) that is: since the joserfc migration non-RSA keys were rejected by PrivateKeyJWT.sign.

The fix consists in letting joserfc make the guess. `sign` calls `client_secret_jwt_sign`, which calls `_sign`, which calls `sign_jwt_bearer_assertion`, which calls `import_any_key`, which calls `joserfc.jwk.import_key`.

**Checklist**

- [x] The commits follow the [conventional commits](https://www.conventionalcommits.org) specification.
- [x] You ran the linters with ``prek``.
- [x] You wrote unit test to demonstrate the bug you are fixing, or to stress the feature you are bringing.
- [x] You reached 100% of code coverage on the code you edited, without abusive use of `pragma: no cover`
- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
