### PR TITLE
Allow non-recommended algorithms in ClientSecretJWT and PrivateKey

### DIFF
--- a/authlib/oauth2/rfc7523/assertion.py
+++ b/authlib/oauth2/rfc7523/assertion.py
@@ -44,7 +44,7 @@ def sign_jwt_bearer_assertion(
     if claims:
         payload.update(claims)
 
-    return jwt.encode(header, payload, import_any_key(key))
+    return jwt.encode(header, payload, import_any_key(key), algorithms=[header["alg"]])
 
 
 def client_secret_jwt_sign(

--- a/docs/upgrades/changelog.rst
+++ b/docs/upgrades/changelog.rst
@@ -6,6 +6,15 @@ Changelog
 
 Here you can see the full list of changes between each Authlib release.
 
+Version 1.7.2
+-------------
+
+**Unreleased**
+
+- Allow ``ClientSecretJWT`` and ``PrivateKeyJWT`` to sign client assertions
+  with non-recommended algorithms (e.g. ``RS384``) when explicitly set via the
+  ``alg`` parameter. :issue:`883`
+
 Version 1.7.1
 -------------
 

--- a/tests/core/test_oauth2/test_rfc7523_private_key.py
+++ b/tests/core/test_oauth2/test_rfc7523_private_key.py
@@ -229,3 +229,17 @@ def test_sign_with_additional_claims():
         "role": "bar",
     }
     assert {"alg": "RS256", "typ": "JWT"} == decoded.header
+
+
+def test_sign_with_non_recommended_alg():
+    """Signing must work with algorithms outside joserfc's recommended set."""
+    jwt_signer = PrivateKeyJWT(alg="RS384")
+
+    auth = mock.MagicMock()
+    auth.client_id = "client_id_1"
+    auth.client_secret = private_key
+
+    data = jwt_signer.sign(auth, "https://provider.test/oauth/access_token")
+    decoded = jwt.decode(data, RSAKey.import_key(public_key), algorithms=["RS384"])
+
+    assert decoded.header["alg"] == "RS384"


### PR DESCRIPTION
fix #883