### PR TITLE
feat: Auto-propagate kid and alg from JWK to JWT header in RFC 7523 assertion signing

### DIFF
--- a/authlib/oauth2/rfc7523/assertion.py
+++ b/authlib/oauth2/rfc7523/assertion.py
@@ -1,9 +1,26 @@
 import time
+from typing import Any
 
 from joserfc import jwt
+from joserfc._rfc7517.models import BaseKey
 
 from authlib._joserfc_helpers import import_any_key
 from authlib.common.security import generate_token
+
+
+def set_jwt_header_parameter_from_key(
+    header: dict[str, Any], key: Any, parameter_name: str
+) -> None:
+    """
+    Copy a JWK parameter (e.g. alg, kid) from key into header.
+
+    The key's value is an enforced constraint and takes priority over any
+    value already present in header.
+    """
+    if isinstance(key, BaseKey):
+        parameter_value = key.get(parameter_name)
+        if parameter_value:
+            header[parameter_name] = parameter_value
 
 
 def sign_jwt_bearer_assertion(
@@ -17,13 +34,18 @@ def sign_jwt_bearer_assertion(
     header=None,
     **kwargs,
 ):
+    _key = import_any_key(key)
+
     if header is None:
         header = {}
     alg = kwargs.pop("alg", None)
     if alg:
         header["alg"] = alg
+    set_jwt_header_parameter_from_key(header=header, key=_key, parameter_name="alg")
     if "alg" not in header:
         raise ValueError("Missing 'alg' in header")
+
+    set_jwt_header_parameter_from_key(header=header, key=_key, parameter_name="kid")
 
     payload = {"iss": issuer, "aud": audience}
 
@@ -44,7 +66,7 @@ def sign_jwt_bearer_assertion(
     if claims:
         payload.update(claims)
 
-    return jwt.encode(header, payload, import_any_key(key), algorithms=[header["alg"]])
+    return jwt.encode(header, payload, _key, algorithms=[header["alg"]])
 
 
 def client_secret_jwt_sign(

--- a/authlib/oauth2/rfc7523/assertion.py
+++ b/authlib/oauth2/rfc7523/assertion.py
@@ -2,7 +2,10 @@ import time
 from typing import Any
 
 from joserfc import jwt
-from joserfc._rfc7517.models import BaseKey
+from joserfc.jwk import ECKey
+from joserfc.jwk import OctKey
+from joserfc.jwk import OKPKey
+from joserfc.jwk import RSAKey
 
 from authlib._joserfc_helpers import import_any_key
 from authlib.common.security import generate_token
@@ -17,7 +20,7 @@ def set_jwt_header_parameter_from_key(
     The key's value is an enforced constraint and takes priority over any
     value already present in header.
     """
-    if isinstance(key, BaseKey):
+    if isinstance(key, (OctKey, RSAKey, ECKey, OKPKey)):
         parameter_value = key.get(parameter_name)
         if parameter_value:
             header[parameter_name] = parameter_value

--- a/tests/core/test_oauth2/test_rfc7523_auto_propagation.py
+++ b/tests/core/test_oauth2/test_rfc7523_auto_propagation.py
@@ -1,0 +1,168 @@
+"""Tests for automatic propagation of kid and alg from JWK to JWT header.
+
+When a key already carries kid and/or alg metadata, the assertion signing
+functions should copy them into the JWT header automatically so callers
+don't have to repeat what is already in the key.
+"""
+
+import pytest
+from joserfc import jwt
+from joserfc.jwk import ECKey
+from joserfc.jwk import OctKey
+from joserfc.jwk import OKPKey
+
+from authlib.oauth2.rfc7523.assertion import client_secret_jwt_sign
+from authlib.oauth2.rfc7523.assertion import private_key_jwt_sign
+from authlib.oauth2.rfc7523.assertion import set_jwt_header_parameter_from_key
+from authlib.oauth2.rfc7523.assertion import sign_jwt_bearer_assertion
+
+CLIENT_ID = "test-client"
+TOKEN_ENDPOINT = "https://auth.example.com/token"
+
+
+# -- set_jwt_header_parameter_from_key ---------------------------------------
+
+
+def test_set_header_param_copies_from_key():
+    key = OctKey.generate_key(384, parameters={"alg": "HS384", "kid": "k1"})
+    header: dict = {}
+
+    set_jwt_header_parameter_from_key(header, key, "alg")
+    set_jwt_header_parameter_from_key(header, key, "kid")
+
+    assert header == {"alg": "HS384", "kid": "k1"}
+
+
+def test_set_header_param_overwrites_existing_value():
+    """Key's value is an enforced constraint and must take priority."""
+    key = OctKey.generate_key(384, parameters={"alg": "HS384"})
+    header = {"alg": "HS512"}
+
+    set_jwt_header_parameter_from_key(header, key, "alg")
+
+    assert header["alg"] == "HS384"
+
+
+def test_set_header_param_noop_when_key_lacks_param():
+    key = OctKey.generate_key(256)
+    header = {"alg": "HS384"}
+
+    set_jwt_header_parameter_from_key(header, key, "kid")
+
+    assert "kid" not in header
+
+
+def test_set_header_param_noop_for_non_base_key():
+    header: dict = {}
+
+    set_jwt_header_parameter_from_key(header, "raw-secret", "alg")
+
+    assert header == {}
+
+
+# -- sign_jwt_bearer_assertion — alg priority --------------------------------
+
+
+def test_alg_resolved_from_key_when_no_explicit_alg():
+    key = OctKey.generate_key(384, parameters={"alg": "HS384"})
+
+    token = sign_jwt_bearer_assertion(
+        key=key, issuer=CLIENT_ID, audience=TOKEN_ENDPOINT
+    )
+
+    decoded = jwt.decode(token, key, algorithms=["HS384"])
+    assert decoded.header["alg"] == "HS384"
+
+
+def test_key_alg_overwrites_explicit_alg():
+    key = OctKey.generate_key(384, parameters={"alg": "HS384"})
+
+    token = sign_jwt_bearer_assertion(
+        key=key, issuer=CLIENT_ID, audience=TOKEN_ENDPOINT, alg="HS512"
+    )
+
+    decoded = jwt.decode(token, key, algorithms=["HS384"])
+    assert decoded.header["alg"] == "HS384"
+
+
+def test_raises_when_no_alg_available():
+    key = OctKey.generate_key(256)
+
+    with pytest.raises(ValueError, match="Missing 'alg'"):
+        sign_jwt_bearer_assertion(key=key, issuer=CLIENT_ID, audience=TOKEN_ENDPOINT)
+
+
+# -- sign_jwt_bearer_assertion — kid propagation -----------------------------
+
+
+def test_kid_propagated_from_key():
+    key = OctKey.generate_key(384, parameters={"alg": "HS384", "kid": "oct-1"})
+
+    token = sign_jwt_bearer_assertion(
+        key=key, issuer=CLIENT_ID, audience=TOKEN_ENDPOINT
+    )
+
+    decoded = jwt.decode(token, key, algorithms=["HS384"])
+    assert decoded.header["kid"] == "oct-1"
+
+
+def test_no_kid_when_key_has_none():
+    key = OctKey.generate_key(384, parameters={"alg": "HS384"})
+
+    token = sign_jwt_bearer_assertion(
+        key=key, issuer=CLIENT_ID, audience=TOKEN_ENDPOINT
+    )
+
+    decoded = jwt.decode(token, key, algorithms=["HS384"])
+    assert "kid" not in decoded.header
+
+
+# -- client_secret_jwt_sign — auto-propagation -------------------------------
+
+
+def test_client_secret_jwt_propagates_alg_and_kid():
+    """Key's HS384 overrides the default HS256; kid is also propagated."""
+    key = OctKey.generate_key(384, parameters={"alg": "HS384", "kid": "hmac-1"})
+
+    token = client_secret_jwt_sign(
+        client_secret=key, client_id=CLIENT_ID, token_endpoint=TOKEN_ENDPOINT
+    )
+
+    decoded = jwt.decode(token, key, algorithms=["HS384"])
+    assert decoded.header["alg"] == "HS384"
+    assert decoded.header["kid"] == "hmac-1"
+
+
+# -- private_key_jwt_sign — auto-propagation ---------------------------------
+
+
+def test_private_key_jwt_propagates_ed25519():
+    """Ed25519 key's EdDSA alg overrides the default RS256; kid propagated."""
+    key = OKPKey.generate_key(
+        crv="Ed25519", private=True, parameters={"alg": "Ed25519", "kid": "ed-1"}
+    )
+
+    token = private_key_jwt_sign(
+        private_key=key, client_id=CLIENT_ID, token_endpoint=TOKEN_ENDPOINT
+    )
+
+    decoded = jwt.decode(token, key, algorithms=["Ed25519"])
+    assert decoded.header["alg"] == "Ed25519"
+    assert decoded.header["kid"] == "ed-1"
+    assert decoded.claims["iss"] == CLIENT_ID
+    assert decoded.claims["sub"] == CLIENT_ID
+    assert decoded.claims["aud"] == TOKEN_ENDPOINT
+
+
+def test_private_key_jwt_propagates_ec_p256():
+    key = ECKey.generate_key(
+        crv="P-256", private=True, parameters={"alg": "ES256", "kid": "ec-1"}
+    )
+
+    token = private_key_jwt_sign(
+        private_key=key, client_id=CLIENT_ID, token_endpoint=TOKEN_ENDPOINT
+    )
+
+    decoded = jwt.decode(token, key, algorithms=["ES256"])
+    assert decoded.header["alg"] == "ES256"
+    assert decoded.header["kid"] == "ec-1"


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This is a feature implementation.

For the OAuth2 client credentials flow, when using `private_key_jwt` or `client_secret_jwt` authentication with a `JWK` that already contains `kid` and `alg`, the caller still has to extract those values from the key and pass them separately, even though the key itself is already passed to the function. This is cumbersome, especially in projects with many OAuth2 clients, where every call site has to repeat the same boilerplate. E.g.,

Before: 
```python
from joserfc.jwk import OKPKey, OctKey
 
 # Example 1: Ed25519 private key (private_key_jwt)
 ed25519_key = OKPKey.generate_key(crv="Ed25519")
 ed25519_key.update({"kid": "ed25519-key-1", "alg": "Ed25519"})
 
 # Manually extract kid and alg from the key we already pass
 token = private_key_jwt_sign(
     private_key=ed25519_key,
     client_id="my-client",
     token_endpoint="https://auth.example.com/token",
     alg=ed25519_key.get("alg"),               # redundant
     header={"kid": ed25519_key.get("kid")},   # redundant
 )
 
 # Example 2: HMAC shared secret (client_secret_jwt)
 hmac_key = OctKey.import_key(shared_secret)
 hmac_key.update({"kid": "hmac-key-1", "alg": "HS384"})
 
 # Same boilerplate for every call site in the project
 token = client_secret_jwt_sign(
     client_secret=hmac_key,
     client_id="another-client",
     token_endpoint="https://auth.example.com/token",
     alg=hmac_key.get("alg"),               # redundant
     header={"kid": hmac_key.get("kid")},   # redundant
 )
```

Solution: Automatically copy `kid` and `alg` from the `JWK` into the `JWT` header via a new helper `set_jwt_header_parameter_from_key(...)`. The key's value is an enforced constraint (joserfc raises if `header alg != key alg`), so it takes priority over any explicit value.

Priority order:

 1. `key.alg / key.kid` — highest priority (enforced by joserfc)
 2. Explicit `alg/kid` parameter — used when key has no `alg/kid`
 3. Function default — `HS256` for `client_secret_jwt_sign`, `RS256` for `private_key_jwt_sign`

After:
```python
from joserfc.jwk import OKPKey, OctKey
 
 # Example 1: Ed25519 private key
 ed25519_key = OKPKey.generate_key(crv="Ed25519")
 ed25519_key.update({"kid": "ed25519-key-1", "alg": "Ed25519"})
 
 # Just pass the key — kid and alg are read from it automatically
 token = private_key_jwt_sign(
     private_key=ed25519_key,
     client_id="my-client",
     token_endpoint="https://auth.example.com/token",
 )
 
 # Example 2: HMAC shared secret
 hmac_key = OctKey.import_key(shared_secret)
 hmac_key.update({"kid": "hmac-key-1", "alg": "HS384"})
 
 # Same simplification — no manual extraction needed
 token = client_secret_jwt_sign(
     client_secret=hmac_key,
     client_id="another-client",
     token_endpoint="https://auth.example.com/token",
 )
```

Fully backward compatible:
   - Keys without `alg/kid` → behavior unchanged, explicit params or defaults apply
   - Keys with `alg/kid` → they were already required to match (joserfc enforces this), so auto-propagation just removes the redundant boilerplate

**Checklist**

- [x] The commits follow the [conventional commits](https://www.conventionalcommits.org) specification.
- [x] You ran the linters with ``prek``.
- [x] You wrote unit test to demonstrate the bug you are fixing, or to stress the feature you are bringing.
- [x] You reached 100% of code coverage on the code you edited, without abusive use of `pragma: no cover`
- [ ] If this PR is about a new feature, or a behavior change, you have updated the documentation accordingly.

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
