### PR TITLE
feat:  Forward extra kwargs (expires_in, issued_at) through ClientSecretJWT and PrivateKeyJWT

### DIFF
--- a/authlib/oauth2/rfc7523/auth.py
+++ b/authlib/oauth2/rfc7523/auth.py
@@ -1,7 +1,7 @@
-from joserfc.jwk import OctKey
-from joserfc.jwk import RSAKey
 from joserfc.jwk import ECKey
+from joserfc.jwk import OctKey
 from joserfc.jwk import OKPKey
+from joserfc.jwk import RSAKey
 
 from authlib.common.urls import add_params_to_qs
 
@@ -32,17 +32,22 @@ class ClientSecretJWT:
     :param claims: Extra JWT claims
     :param headers: Extra JWT headers
     :param alg: ``alg`` value, default is HS256
+    :param kwargs: Extra keyword arguments forwarded to client_secret_jwt_sign(...),
+        e.g. expires_in (default 3600) and issued_at.
     """
 
     name = "client_secret_jwt"
     alg = "HS256"
 
-    def __init__(self, token_endpoint=None, claims=None, headers=None, alg=None):
+    def __init__(
+        self, token_endpoint=None, claims=None, headers=None, alg=None, **kwargs
+    ):
         self.token_endpoint = token_endpoint
         self.claims = claims
         self.headers = headers
         if alg is not None:
             self.alg = alg
+        self.kwargs = kwargs
 
     def sign(self, auth, token_endpoint):
         if isinstance(auth.client_secret, OctKey):
@@ -56,6 +61,7 @@ class ClientSecretJWT:
             claims=self.claims,
             header=self.headers,
             alg=self.alg,
+            **self.kwargs,
         )
 
     def __call__(self, auth, method, uri, headers, body):
@@ -96,6 +102,8 @@ class PrivateKeyJWT(ClientSecretJWT):
     :param claims: Extra JWT claims
     :param headers: Extra JWT headers
     :param alg: ``alg`` value, default is RS256
+    :param kwargs: Extra keyword arguments forwarded to private_key_jwt_sign(...),
+        e.g. expires_in (default 3600) and issued_at.
     """
 
     name = "private_key_jwt"
@@ -113,4 +121,5 @@ class PrivateKeyJWT(ClientSecretJWT):
             claims=self.claims,
             header=self.headers,
             alg=self.alg,
+            **self.kwargs,
         )

--- a/tests/core/test_oauth2/test_rfc7523_client_secret.py
+++ b/tests/core/test_oauth2/test_rfc7523_client_secret.py
@@ -232,3 +232,18 @@ def test_sign_with_additional_claims():
         "role": "bar",
     }
     assert {"alg": "HS256", "typ": "JWT"} == decoded.header
+
+
+def test_sign_with_custom_issued_at_and_expires_in():
+    fixed_iat = 123456789
+    jwt_signer = ClientSecretJWT(issued_at=fixed_iat, expires_in=123)
+
+    decoded, pre_sign_time, iat, exp, jti = sign_and_decode(
+        jwt_signer,
+        "client_id_1",
+        "client_secret_1",
+        "https://provider.test/oauth/access_token",
+    )
+
+    assert iat == fixed_iat
+    assert exp == fixed_iat + 123

--- a/tests/core/test_oauth2/test_rfc7523_private_key.py
+++ b/tests/core/test_oauth2/test_rfc7523_private_key.py
@@ -260,3 +260,17 @@ def test_sign_with_non_recommended_alg():
     decoded = jwt.decode(data, RSAKey.import_key(public_key), algorithms=["RS384"])
 
     assert decoded.header["alg"] == "RS384"
+
+
+def test_sign_with_custom_issued_at_and_expires_in():
+    fixed_iat = 123456789
+    jwt_signer = PrivateKeyJWT(issued_at=fixed_iat, expires_in=123)
+
+    decoded, pre_sign_time, iat, exp, jti = sign_and_decode(
+        jwt_signer,
+        "client_id_1",
+        "https://provider.test/oauth/access_token",
+    )
+
+    assert iat == fixed_iat
+    assert exp == fixed_iat + 123


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This is a feature implementation

`ClientSecretJWT` and `PrivateKeyJWT` accept `token_endpoint, claims, headers, and alg`,  but there is no way to control `expires_in` or `issued_at` for the generated JWT assertion. The underlying `sign_jwt_bearer_assertion` already supports these parameters, but they were not forwarded from the high-level classes.

Before:
```
 # No way to set a shorter token lifetime
 jwt_signer = ClientSecretJWT(token_endpoint="https://example.com/token")
 # Always generates a JWT with exp = iat + 3600 (1 hour)
```

Solution: Accept `**kwargs` in `__init__(...)` and forward them through `sign()` to `client_secret_jwt_sign` / `private_key_jwt_sign`, which already pass `**kwargs` to `sign_jwt_bearer_assertion`.

After: 
```
 # Control expires_in and issued_at
 jwt_signer = ClientSecretJWT(
     token_endpoint="https://example.com/token",
     expires_in=300,  # 5-minute token lifetime
 )
 
 jwt_signer = PrivateKeyJWT(
     token_endpoint="https://example.com/token",
     issued_at=1700000000,
     expires_in=600,
 )
```

Fully backward compatible. No existing parameters changed. The kwargs only captures additional keyword arguments.

**Checklist**

- [x] The commits follow the [conventional commits](https://www.conventionalcommits.org) specification.
- [x] You ran the linters with ``prek``.
- [x] You wrote unit test to demonstrate the bug you are fixing, or to stress the feature you are bringing.
- [x] You reached 100% of code coverage on the code you edited, without abusive use of `pragma: no cover`
- [ ] If this PR is about a new feature, or a behavior change, you have updated the documentation accordingly.

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
