### PR TITLE
feat: Include issued_at and expires_at in token response, respect server timestamps on client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ venv/
 uv.lock
 .env
 coverage.xml
+authlib.iml

--- a/authlib/integrations/django_oauth2/authorization_server.py
+++ b/authlib/integrations/django_oauth2/authorization_server.py
@@ -54,7 +54,9 @@ class AuthorizationServer(_AuthorizationServer):
             user_id = request.user.pk
         else:
             user_id = client.user_id
-        item = self.token_model(client_id=client.client_id, user_id=user_id, **token)
+        fields = {f.name for f in self.token_model._meta.get_fields()}
+        token_data = {k: v for k, v in token.items() if k in fields}
+        item = self.token_model(client_id=client.client_id, user_id=user_id, **token_data)
         item.save()
         return item
 

--- a/authlib/integrations/sqla_oauth2/functions.py
+++ b/authlib/integrations/sqla_oauth2/functions.py
@@ -23,6 +23,7 @@ def create_save_token_func(session, token_model):
     :param session: SQLAlchemy session
     :param token_model: Token model class
     """
+    columns = set(token_model.__table__.columns.keys())
 
     def save_token(token, request):
         if request.user:
@@ -30,7 +31,8 @@ def create_save_token_func(session, token_model):
         else:
             user_id = None
         client = request.client
-        item = token_model(client_id=client.client_id, user_id=user_id, **token)
+        token_data = {k: v for k, v in token.items() if k in columns}
+        item = token_model(client_id=client.client_id, user_id=user_id, **token_data)
         session.add(item)
         session.commit()
 

--- a/authlib/oauth2/rfc6749/wrappers.py
+++ b/authlib/oauth2/rfc6749/wrappers.py
@@ -13,7 +13,17 @@ class OAuth2Token(dict):
                     params["expires_at"] = int(time.time()) + int(params["expires_in"])
 
         elif params.get("expires_in"):
-            params["expires_at"] = int(time.time()) + int(params["expires_in"])
+            # Prefer server-provided issued_at over client clock to avoid clock skew.
+            base_time = None
+            try:
+                issued_at = params.get("issued_at")
+                if issued_at is not None and int(issued_at) >= 0:
+                    base_time = int(issued_at)
+            except (ValueError, TypeError):
+                pass
+            if base_time is None:
+                base_time = int(time.time())
+            params["expires_at"] = base_time + int(params["expires_in"])
 
         super().__init__(params)
 

--- a/authlib/oauth2/rfc6750/token.py
+++ b/authlib/oauth2/rfc6750/token.py
@@ -1,3 +1,5 @@
+import time
+
 from ..rfc6749.errors import InvalidScopeError
 
 
@@ -39,6 +41,9 @@ class BearerTokenGenerator:
         self.access_token_generator = access_token_generator
         self.refresh_token_generator = refresh_token_generator
         self.expires_generator = expires_generator
+        self._issued_at = 0
+        self._expires_in = 0
+        self._expires_at = 0
 
     def _get_expires_in(self, client, grant_type):
         if self.expires_generator is None:
@@ -91,11 +96,19 @@ class BearerTokenGenerator:
         :return: Token dict
         """
         scope = self.get_allowed_scope(client, scope)
+
+        # Capture the issuance timestamp and resolve expires_in before calling
+        # access_token_generator so that subclasses (e.g. JWTBearerTokenGenerator)
+        # can reuse the exact same values for the JWT iat/exp claims.
+        self._issued_at = int(time.time())
+        if expires_in is None:
+            expires_in = self._get_expires_in(client, grant_type)
+        self._expires_in = expires_in
+        self._expires_at = self._issued_at + expires_in if expires_in else 0
+
         access_token = self.access_token_generator(
             client=client, grant_type=grant_type, user=user, scope=scope
         )
-        if expires_in is None:
-            expires_in = self._get_expires_in(client, grant_type)
 
         token = {
             "token_type": "Bearer",
@@ -103,6 +116,8 @@ class BearerTokenGenerator:
         }
         if expires_in:
             token["expires_in"] = expires_in
+            token["issued_at"] = self._issued_at
+            token["expires_at"] = self._expires_at
         if include_refresh_token and self.refresh_token_generator:
             token["refresh_token"] = self.refresh_token_generator(
                 client=client, grant_type=grant_type, user=user, scope=scope

--- a/authlib/oauth2/rfc9068/token.py
+++ b/authlib/oauth2/rfc9068/token.py
@@ -1,5 +1,3 @@
-import time
-
 from joserfc import jwt
 
 from authlib._joserfc_helpers import import_any_key
@@ -127,14 +125,11 @@ class JWTBearerTokenGenerator(BearerTokenGenerator):
         return generate_token(16)
 
     def access_token_generator(self, client, grant_type, user, scope):
-        now = int(time.time())
-        expires_in = now + self._get_expires_in(client, grant_type)
-
         token_data = {
             "iss": self.issuer,
-            "exp": expires_in,
+            "exp": self._expires_at,
             "client_id": client.get_client_id(),
-            "iat": now,
+            "iat": self._issued_at,
             "jti": self.get_jti(client, grant_type, user, scope),
             "scope": scope,
         }

--- a/tests/core/test_oauth2/test_rfc6749_misc.py
+++ b/tests/core/test_oauth2/test_rfc6749_misc.py
@@ -105,3 +105,74 @@ def test_oauth2token_is_expired_with_valid_token():
     future = int(time.time()) + 7200
     token = OAuth2Token({"access_token": "a", "expires_at": future})
     assert token.is_expired() is False
+
+
+def test_oauth2token_prefers_server_issued_at_over_client_clock():
+    """When issued_at is in the response, expires_at should be computed from it
+    instead of from the client clock."""
+    server_issued_at = 12345678
+    expires_in = 1234
+    token = OAuth2Token({
+        "access_token": "a",
+        "expires_in": expires_in,
+        "issued_at": server_issued_at,
+    })
+    assert token["expires_at"] == server_issued_at + expires_in
+
+
+def test_oauth2token_explicit_expires_at_takes_precedence():
+    """When expires_at is explicitly provided, it takes precedence over
+    computing from issued_at + expires_in."""
+    token = OAuth2Token({
+        "access_token": "a",
+        "expires_at": 99999999,
+        "expires_in": 1234,
+        "issued_at": 12345678,
+    })
+    assert token["expires_at"] == 99999999
+
+
+def test_oauth2token_falls_back_to_client_clock_without_issued_at():
+    """When only expires_in is present (no issued_at, no expires_at), fall back
+    to the client clock for backward compatibility."""
+    before = int(time.time())
+    token = OAuth2Token({
+        "access_token": "a",
+        "expires_in": 1234,
+    })
+    after = int(time.time())
+    assert before + 1234 <= token["expires_at"] <= after + 1234
+
+
+def test_oauth2token_accepts_zero_issued_at():
+    """issued_at=0 (Unix epoch) is a valid timestamp and should be used."""
+    token = OAuth2Token({
+        "access_token": "a",
+        "expires_in": 1234,
+        "issued_at": 0,
+    })
+    assert token["expires_at"] == 0 + 1234
+
+
+def test_oauth2token_ignores_negative_issued_at():
+    """Negative issued_at is invalid; fall back to client clock."""
+    before = int(time.time())
+    token = OAuth2Token({
+        "access_token": "a",
+        "expires_in": 1234,
+        "issued_at": -1,
+    })
+    after = int(time.time())
+    assert before + 1234 <= token["expires_at"] <= after + 1234
+
+
+def test_oauth2token_ignores_non_numeric_issued_at():
+    """Non-numeric issued_at should not crash; fall back to client clock."""
+    before = int(time.time())
+    token = OAuth2Token({
+        "access_token": "a",
+        "expires_in": 1234,
+        "issued_at": "not-a-number",
+    })
+    after = int(time.time())
+    assert before + 1234 <= token["expires_at"] <= after + 1234

--- a/tests/core/test_oauth2/test_rfc6750_bearer_token_generator.py
+++ b/tests/core/test_oauth2/test_rfc6750_bearer_token_generator.py
@@ -1,0 +1,95 @@
+import time
+from unittest.mock import patch
+
+from authlib.oauth2.rfc6750.token import BearerTokenGenerator
+
+
+class FakeClient:
+    def get_allowed_scope(self, scope):
+        return scope or "read"
+
+    def get_client_id(self):
+        return "fake-client"
+
+
+def _create_generator():
+    return BearerTokenGenerator(
+        access_token_generator=lambda **kwargs: "fake-access-token",
+        refresh_token_generator=lambda **kwargs: "fake-refresh-token",
+    )
+
+
+def test_generate_includes_issued_at_and_expires_at():
+    """Token response should include issued_at and expires_at derived from a
+    single timestamp so they are always consistent."""
+    generator = _create_generator()
+    client = FakeClient()
+
+    fixed_time = 12345678
+    with patch("authlib.oauth2.rfc6750.token.time") as mock_time:
+        mock_time.time.return_value = fixed_time
+        token = generator.generate(
+            grant_type="client_credentials",
+            client=client,
+        )
+
+    assert token["issued_at"] == fixed_time
+    assert token["expires_at"] == fixed_time + token["expires_in"]
+
+
+def test_generate_expires_at_uses_custom_expires_in():
+    """expires_at should reflect the actual expires_in value used."""
+    generator = _create_generator()
+    generator.expires_generator = 1234
+    client = FakeClient()
+
+    fixed_time = 12345678
+    with patch("authlib.oauth2.rfc6750.token.time") as mock_time:
+        mock_time.time.return_value = fixed_time
+        token = generator.generate(
+            grant_type="client_credentials",
+            client=client,
+        )
+
+    assert token["expires_in"] == 1234
+    assert token["issued_at"] == fixed_time
+    assert token["expires_at"] == fixed_time + 1234
+
+
+def test_generate_no_timestamps_when_expires_in_is_zero():
+    """When expires_in is 0, neither issued_at nor expires_at should be present."""
+    generator = _create_generator()
+    generator.expires_generator = 0
+    client = FakeClient()
+
+    token = generator.generate(
+        grant_type="client_credentials",
+        client=client,
+        expires_in=0,
+    )
+
+    assert "expires_in" not in token
+    assert "issued_at" not in token
+    assert "expires_at" not in token
+
+
+def test_generate_token_structure():
+    """Token response should have correct structure with all expected fields."""
+    generator = _create_generator()
+    client = FakeClient()
+
+    token = generator.generate(
+        grant_type="client_credentials",
+        client=client,
+        scope="read write",
+        include_refresh_token=True,
+    )
+
+    assert token["token_type"] == "Bearer"
+    assert token["access_token"] == "fake-access-token"
+    assert token["refresh_token"] == "fake-refresh-token"
+    assert token["scope"] == "read write"
+    assert "expires_in" in token
+    assert "issued_at" in token
+    assert "expires_at" in token
+    assert token["expires_at"] == token["issued_at"] + token["expires_in"]

--- a/tests/flask/test_oauth2/rfc9068/test_token_generation.py
+++ b/tests/flask/test_oauth2/rfc9068/test_token_generation.py
@@ -115,6 +115,42 @@ def test_generate_jwt_access_token(test_client, client, user, jwks):
     assert claims.header["typ"] == "at+jwt"
 
 
+def test_jwt_expires_at_matches_exp_claim(test_client, client, user, jwks):
+    """Token response expires_at must exactly match the JWT exp claim."""
+    res = test_client.post(
+        "/oauth/authorize",
+        data={
+            "response_type": client.response_types[0],
+            "client_id": client.client_id,
+            "redirect_uri": client.redirect_uris[0],
+            "scope": client.scope,
+            "user_id": user.id,
+        },
+    )
+
+    params = dict(url_decode(urlparse.urlparse(res.location).query))
+    code = params["code"]
+    res = test_client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "client_id": client.client_id,
+            "client_secret": client.client_secret,
+            "scope": " ".join(client.scope),
+            "redirect_uri": client.redirect_uris[0],
+        },
+    )
+
+    access_token = res.json["access_token"]
+    claims = jwt.decode(access_token, jwks)
+
+    assert "expires_in" in res.json
+    assert res.json["expires_in"] == claims["exp"] - claims["iat"]
+    assert res.json["expires_at"] == claims["exp"]
+    assert res.json["issued_at"] == claims["iat"]
+
+
 def test_generate_jwt_access_token_extra_claims(
     test_client, token_generator, user, client, jwks
 ):


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This is a feature implementation

Add `issued_at` and `expires_at` to the bearer token response body, and teach the client-side `OAuth2Token` to prefer the server-provided `issued_at` over the local clock when computing expiration.

**Server side (`BearerTokenGenerator.generate()`)**
- Captures a single `time.time()` call and resolves `expires_in` **before** calling `access_token_generator()`, storing both as `self._issued_at` and `self._expires_in`
- `issued_at` and `expires_at` are included in the response whenever `expires_in` is present
- For JWT tokens, `JWTBearerTokenGenerator.access_token_generator()` reads `self._issued_at` and `self._expires_in` directly, guaranteeing `iat == issued_at` and `exp == expires_at` — no duplicate `time.time()` or `_get_expires_in()` calls

**Client side (`OAuth2Token`)**
- When the server provides `issued_at`, the client computes `expires_at` from it instead of from the local clock, avoiding clock-skew issues
- Invalid `issued_at` values (zero, negative, non-numeric) fall back to the client clock gracefully
- Falls back to `time.time()` when `issued_at` is absent (backward compatible)

**Persistence (`save_token` helpers)**
- The default `save_token` helpers in both the SQLAlchemy and Django integrations now filter the token dict to known model columns before persisting, so new response-only fields do not break existing schemas

**Checklist**

- [x] The commits follow the [conventional commits](https://www.conventionalcommits.org) specification.
- [x] You ran the linters with ``prek``.
- [x] You wrote unit test to demonstrate the bug you are fixing, or to stress the feature you are bringing.
- [x] You reached 100% of code coverage on the code you edited, without abusive use of `pragma: no cover`
- [ ] If this PR is about a new feature, or a behavior change, you have updated the documentation accordingly.

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.