### PR TITLE
feat: fallback to trying all JWKS keys when kid does not match

### DIFF
--- a/authlib/integrations/base_client/async_openid.py
+++ b/authlib/integrations/base_client/async_openid.py
@@ -8,6 +8,8 @@ from authlib.oidc.core import CodeIDToken
 from authlib.oidc.core import ImplicitIDToken
 from authlib.oidc.core import UserInfo
 
+from .sync_openid import try_all_keys
+
 __all__ = ["AsyncOpenIDMixin"]
 
 
@@ -63,20 +65,26 @@ class AsyncOpenIDMixin:
 
         jwks = await self.fetch_jwk_set()
         key_set = KeySet.import_key_set(jwks)
+        id_token_value = token["id_token"]
         try:
-            token = jwt.decode(
-                token["id_token"],
-                key=key_set,
-                algorithms=alg_values,
-            )
+            token = jwt.decode(id_token_value, key=key_set, algorithms=alg_values)
         except InvalidKeyIdError:
+            # Refresh JWKS — keys may have rotated
             jwks = await self.fetch_jwk_set(force=True)
             key_set = KeySet.import_key_set(jwks)
-            token = jwt.decode(
-                token["id_token"],
-                key=key_set,
-                algorithms=alg_values,
-            )
+            try:
+                token = jwt.decode(
+                    id_token_value, key=key_set, algorithms=alg_values
+                )
+            except InvalidKeyIdError:
+                if self.should_try_all_keys():
+                    token = try_all_keys(
+                        id_token_value=id_token_value,
+                        key_set=key_set,
+                        algorithms=alg_values,
+                    )
+                else:
+                    raise
 
         claims = claims_cls(token.claims, token.header, claims_options, claims_params)
         # https://github.com/authlib/authlib/issues/259
@@ -84,6 +92,17 @@ class AsyncOpenIDMixin:
             claims.params["nonce"] = None
         claims.validate(leeway=leeway)
         return UserInfo(claims)
+
+    def should_try_all_keys(self):
+        """Control whether to attempt signature verification against every key
+        in the JWKS when the token's kid does not match any key.
+
+        The default is False, which preserves the standard behavior of raising
+        InvalidKeyIdError immediately.  Override this method to return True in
+        subclasses that integrate with providers whose JWKS keys lack a kid or
+        use mismatched kid values.
+        """
+        return False
 
     async def create_logout_url(
         self,

--- a/authlib/integrations/base_client/sync_openid.py
+++ b/authlib/integrations/base_client/sync_openid.py
@@ -1,4 +1,6 @@
 from joserfc import jwt
+from joserfc.errors import BadSignatureError
+from joserfc.errors import DecodeError
 from joserfc.errors import InvalidKeyIdError
 from joserfc.jwk import KeySet
 
@@ -43,6 +45,8 @@ class OpenIDMixin:
         if "id_token" not in token:
             return None
 
+        id_token_value = token["id_token"]
+
         claims_params = dict(
             nonce=nonce,
             client_id=self.client_id,
@@ -63,26 +67,44 @@ class OpenIDMixin:
 
         key_set = KeySet.import_key_set(self.fetch_jwk_set())
         try:
-            token = jwt.decode(
-                token["id_token"],
-                key=key_set,
-                algorithms=alg_values,
-            )
+            token = jwt.decode(id_token_value, key=key_set, algorithms=alg_values)
         except InvalidKeyIdError:
+            # Refresh JWKS — keys may have rotated
             key_set = KeySet.import_key_set(self.fetch_jwk_set(force=True))
-            token = jwt.decode(
-                token["id_token"],
-                key=key_set,
-                algorithms=alg_values,
-            )
+            try:
+                token = jwt.decode(
+                    id_token_value, key=key_set, algorithms=alg_values
+                )
+            except InvalidKeyIdError:
+                if self.should_try_all_keys():
+                    token = try_all_keys(
+                        id_token_value=id_token_value,
+                        key_set=key_set,
+                        algorithms=alg_values,
+                    )
+                else:
+                    raise
 
-        claims = claims_cls(token.claims, token.header, claims_options, claims_params)
+        claims = claims_cls(
+            token.claims, token.header, claims_options, claims_params
+        )
         # https://github.com/authlib/authlib/issues/259
         if claims.get("nonce_supported") is False:
             claims.params["nonce"] = None
 
         claims.validate(leeway=leeway)
         return UserInfo(claims)
+
+    def should_try_all_keys(self):
+        """Control whether to attempt signature verification against every key
+        in the JWKS when the token's kid does not match any key.
+
+        The default is False, which preserves the standard behavior of raising
+        InvalidKeyIdError immediately.  Override this method to return True in
+        subclasses that integrate with providers whose JWKS keys lack a kid or
+        use mismatched kid values.
+        """
+        return False
 
     def create_logout_url(
         self,
@@ -120,3 +142,18 @@ class OpenIDMixin:
 
         url = add_params_to_uri(end_session_endpoint, params)
         return {"url": url, "state": state}
+
+
+def try_all_keys(id_token_value: str, key_set: KeySet, algorithms) -> jwt.Token:
+    """Try each key in the JWKS individually to find one that verifies the
+    token signature.  Handles providers whose JWKS keys lack a kid field or
+    use kid values that do not match the token header.
+
+    Raises InvalidKeyIdError if no key verifies the signature.
+    """
+    for key in key_set.keys:
+        try:
+            return jwt.decode(id_token_value, key=key, algorithms=algorithms)
+        except (BadSignatureError, DecodeError, ValueError):
+            continue
+    raise InvalidKeyIdError("No key in JWKS verifies the token signature.")

--- a/tests/clients/test_flask/test_parse_id_token_kid.py
+++ b/tests/clients/test_flask/test_parse_id_token_kid.py
@@ -1,0 +1,231 @@
+import time
+from unittest import mock
+
+import pytest
+from flask import Flask
+from joserfc import jwt
+from joserfc.errors import InvalidKeyIdError
+from joserfc.jwk import OctKey
+
+from authlib.integrations.flask_client import OAuth
+from authlib.oidc.core.grants.util import create_half_hash
+
+from ..util import get_bearer_token
+
+
+def _make_id_token(signing_key, kid=None):
+    """Create a signed ID token.
+
+    :param signing_key: OctKey used to sign the token.
+    :param kid: kid to include in the JWT header.  None omits it.
+    """
+    token = get_bearer_token()
+    now = int(time.time())
+    claims = {
+        "sub": "user-42",
+        "nonce": "n",
+        "iss": "https://provider.test",
+        "aud": "dev",
+        "iat": now,
+        "auth_time": now,
+        "exp": now + 3600,
+        "at_hash": create_half_hash(token["access_token"], "HS256").decode("utf-8"),
+    }
+    header = {"alg": "HS256"}
+    if kid is not None:
+        header["kid"] = kid
+    token["id_token"] = jwt.encode(header, claims, signing_key)
+    return token
+
+
+def _fake_jwks_refresh(jwks_dict):
+    """Create a mock send function that returns the given JWKS on refresh."""
+    def fake_send(sess, req, **kwargs):
+        resp = mock.MagicMock()
+        resp.json = lambda: jwks_dict
+        resp.status_code = 200
+        return resp
+    return fake_send
+
+
+def _register_client(app, jwks, jwks_uri="https://provider.test/jwks"):
+    oauth = OAuth(app)
+    return oauth.register(
+        "dev",
+        client_id="dev",
+        client_secret="dev",
+        fetch_token=get_bearer_token,
+        jwks=jwks,
+        jwks_uri=jwks_uri,
+        issuer="https://provider.test",
+        id_token_signing_alg_values_supported=["HS256"],
+    )
+
+
+def test_default_raises_on_kid_mismatch():
+    """Default behavior: kid mismatch raises InvalidKeyIdError after refresh."""
+    signing_key = OctKey.import_key("secret-for-mismatch-test")
+    token = _make_id_token(signing_key, kid="token-kid-1")
+    app = Flask(__name__)
+    app.secret_key = "!"
+
+    key_dict = signing_key.as_dict()
+    key_dict["kid"] = "different-kid"
+    extra_key = OctKey.import_key("extra-key-material-xxxxx")
+    extra_dict = extra_key.as_dict()
+    extra_dict["kid"] = "extra-kid"
+    jwks = {"keys": [key_dict, extra_dict]}
+    client = _register_client(app, jwks)
+
+    with app.test_request_context():
+        with mock.patch("requests.sessions.Session.send", _fake_jwks_refresh(jwks)):
+            with pytest.raises(InvalidKeyIdError):
+                client.parse_id_token(token, nonce="n")
+
+
+def test_no_kid_in_token_multiple_jwks_keys_needs_fallback():
+    """Token without kid + multiple JWKS keys raises unless fallback enabled."""
+    signing_key = OctKey.import_key("secret-for-multi-key-test")
+    token = _make_id_token(signing_key, kid=None)
+    app = Flask(__name__)
+    app.secret_key = "!"
+
+    other_key = OctKey.import_key("other-key-material-xxxxx")
+    other_dict = other_key.as_dict()
+    other_dict["kid"] = "key-1"
+    correct_dict = signing_key.as_dict()
+    correct_dict["kid"] = "key-2"
+    jwks = {"keys": [other_dict, correct_dict]}
+
+    client = _register_client(app, jwks)
+    client.should_try_all_keys = lambda: True
+
+    with app.test_request_context():
+        with mock.patch("requests.sessions.Session.send", _fake_jwks_refresh(jwks)):
+            user = client.parse_id_token(token, nonce="n")
+            assert user.sub == "user-42"
+
+
+def test_key_rotation_resolved_by_refresh():
+    """JWKS refresh resolves kid mismatch when provider rotated keys."""
+    signing_key = OctKey.import_key("secret-for-rotation-test")
+    token = _make_id_token(signing_key, kid="new-kid")
+    app = Flask(__name__)
+    app.secret_key = "!"
+
+    # Initial JWKS has old keys that cannot verify the token
+    old_key = OctKey.import_key("old-key-material-xxxxx")
+    old_dict = old_key.as_dict()
+    old_dict["kid"] = "old-kid"
+    old_key2 = OctKey.import_key("old-key-material-yyyyy")
+    old_dict2 = old_key2.as_dict()
+    old_dict2["kid"] = "old-kid-2"
+
+    # After refresh: correct key with matching kid + another key
+    correct_dict = signing_key.as_dict()
+    correct_dict["kid"] = "new-kid"
+
+    client = _register_client(app, {"keys": [old_dict, old_dict2]})
+
+    with app.test_request_context():
+        with mock.patch(
+            "requests.sessions.Session.send",
+            _fake_jwks_refresh({"keys": [correct_dict, old_dict2]}),
+        ):
+            user = client.parse_id_token(token, nonce="n")
+            assert user.sub == "user-42"
+
+
+def test_try_all_keys_with_kid_mismatch():
+    """With should_try_all_keys enabled, fallback finds the correct key."""
+    signing_key = OctKey.import_key("secret-for-try-all-test")
+    token = _make_id_token(signing_key, kid="nonexistent-kid")
+    app = Flask(__name__)
+    app.secret_key = "!"
+
+    wrong_key = OctKey.import_key("wrong-secret-material")
+    correct_dict = signing_key.as_dict()
+    correct_dict["kid"] = "other-kid"
+    jwks = {"keys": [wrong_key.as_dict(), correct_dict]}
+
+    client = _register_client(app, jwks)
+    client.should_try_all_keys = lambda: True
+
+    with app.test_request_context():
+        with mock.patch("requests.sessions.Session.send", _fake_jwks_refresh(jwks)):
+            user = client.parse_id_token(token, nonce="n")
+            assert user.sub == "user-42"
+
+
+def test_try_all_keys_when_jwks_key_has_no_kid():
+    """With should_try_all_keys enabled, works when JWKS keys lack kid."""
+    signing_key = OctKey.import_key("secret-for-jwks-no-kid")
+    token = _make_id_token(signing_key, kid="token-kid")
+    app = Flask(__name__)
+    app.secret_key = "!"
+
+    # JWKS keys have no kid — triggers InvalidKeyIdError for token with kid
+    wrong_key = OctKey.import_key("wrong-key-for-no-kid-test")
+    jwks = {"keys": [wrong_key.as_dict(), signing_key.as_dict()]}
+    client = _register_client(app, jwks)
+    client.should_try_all_keys = lambda: True
+
+    with app.test_request_context():
+        with mock.patch("requests.sessions.Session.send", _fake_jwks_refresh(jwks)):
+            user = client.parse_id_token(token, nonce="n")
+            assert user.sub == "user-42"
+
+
+def test_try_all_keys_no_valid_key_raises():
+    """With should_try_all_keys enabled, raises if no key verifies."""
+    signing_key = OctKey.import_key("secret-for-no-match-test")
+    token = _make_id_token(signing_key, kid="token-kid")
+    app = Flask(__name__)
+    app.secret_key = "!"
+
+    wrong_key1 = OctKey.import_key("completely-different-secret")
+    wrong_dict1 = wrong_key1.as_dict()
+    wrong_dict1["kid"] = "wrong-1"
+    wrong_key2 = OctKey.import_key("another-different-secret")
+    wrong_dict2 = wrong_key2.as_dict()
+    wrong_dict2["kid"] = "wrong-2"
+    jwks = {"keys": [wrong_dict1, wrong_dict2]}
+
+    client = _register_client(app, jwks)
+    client.should_try_all_keys = lambda: True
+
+    with app.test_request_context():
+        with mock.patch("requests.sessions.Session.send", _fake_jwks_refresh(jwks)):
+            with pytest.raises(InvalidKeyIdError):
+                client.parse_id_token(token, nonce="n")
+
+
+def test_no_jwks_uri_raises_runtime_error():
+    """When jwks_uri is absent, JWKS refresh raises RuntimeError."""
+    signing_key = OctKey.import_key("secret-for-no-uri-test")
+    token = _make_id_token(signing_key, kid="token-kid")
+    app = Flask(__name__)
+    app.secret_key = "!"
+
+    # JWKS has the correct key material but wrong kid, triggering refresh
+    key_dict = signing_key.as_dict()
+    key_dict["kid"] = "embedded-kid"
+    extra_key = OctKey.import_key("extra-no-uri-key-material")
+    extra_dict = extra_key.as_dict()
+    extra_dict["kid"] = "extra-kid"
+
+    oauth = OAuth(app)
+    client = oauth.register(
+        "dev",
+        client_id="dev",
+        client_secret="dev",
+        fetch_token=get_bearer_token,
+        jwks={"keys": [key_dict, extra_dict]},
+        # No jwks_uri provided
+        issuer="https://provider.test",
+        id_token_signing_alg_values_supported=["HS256"],
+    )
+
+    with app.test_request_context():
+        with pytest.raises(RuntimeError, match="jwks_uri"):
+            client.parse_id_token(token, nonce="n")

--- a/tests/core/test_oidc/test_parse_id_token_kid.py
+++ b/tests/core/test_oidc/test_parse_id_token_kid.py
@@ -1,0 +1,146 @@
+"""Unit tests for AsyncOpenIDMixin kid handling (no starlette dependency)."""
+import asyncio
+import time
+
+import pytest
+from joserfc import jwt
+from joserfc.errors import InvalidKeyIdError
+from joserfc.jwk import OctKey
+
+from authlib.integrations.base_client.async_openid import AsyncOpenIDMixin
+
+
+def _make_id_token(signing_key, kid=None):
+    """Create a signed ID token.
+
+    :param signing_key: OctKey used to sign the token.
+    :param kid: kid to include in the JWT header.  None omits it.
+    """
+    now = int(time.time())
+    claims = {
+        "sub": "user-42",
+        "nonce": "n",
+        "iss": "https://issuer.test",
+        "aud": "client-1",
+        "iat": now,
+        "auth_time": now,
+        "exp": now + 3600,
+    }
+    header = {"alg": "HS256"}
+    if kid is not None:
+        header["kid"] = kid
+    return jwt.encode(header, claims, signing_key)
+
+
+class FakeAsyncClient(AsyncOpenIDMixin):
+    def __init__(self, jwks, jwks_uri=None, refreshed_jwks=None):
+        self.client_id = "client-1"
+        self.server_metadata = {
+            "jwks": jwks,
+            "issuer": "https://issuer.test",
+            "id_token_signing_alg_values_supported": ["HS256"],
+        }
+        if jwks_uri:
+            self.server_metadata["jwks_uri"] = jwks_uri
+        self._refreshed_jwks = refreshed_jwks or jwks
+
+    async def load_server_metadata(self):
+        return self.server_metadata
+
+    async def fetch_jwk_set(self, force=False):
+        if force:
+            uri = self.server_metadata.get("jwks_uri")
+            if not uri:
+                raise RuntimeError('Missing "jwks_uri" in metadata')
+            self.server_metadata["jwks"] = self._refreshed_jwks
+            return self._refreshed_jwks
+        return self.server_metadata["jwks"]
+
+
+def test_async_default_raises_on_kid_mismatch():
+    """Default: kid mismatch raises InvalidKeyIdError after refresh."""
+    signing_key = OctKey.import_key("secret-for-async-mismatch")
+    key_dict = signing_key.as_dict()
+    key_dict["kid"] = "wrong-kid"
+    extra_key = OctKey.import_key("extra-async-key-material")
+    extra_dict = extra_key.as_dict()
+    extra_dict["kid"] = "extra-kid"
+    jwks = {"keys": [key_dict, extra_dict]}
+    client = FakeAsyncClient(jwks, jwks_uri="https://issuer.test/jwks")
+    token = {"id_token": _make_id_token(signing_key, kid="token-kid-1"), "access_token": "at"}
+
+    with pytest.raises(InvalidKeyIdError):
+        asyncio.run(client.parse_id_token(token, nonce="n"))
+
+
+def test_async_no_kid_in_token_needs_fallback():
+    """Token without kid + multiple JWKS keys raises unless fallback enabled."""
+    signing_key = OctKey.import_key("secret-for-async-multi-key")
+    other_key = OctKey.import_key("other-async-key-material")
+    other_dict = other_key.as_dict()
+    other_dict["kid"] = "key-1"
+    correct_dict = signing_key.as_dict()
+    correct_dict["kid"] = "key-2"
+    jwks = {"keys": [other_dict, correct_dict]}
+
+    client = FakeAsyncClient(jwks, jwks_uri="https://issuer.test/jwks")
+    client.should_try_all_keys = lambda: True
+    token = {"id_token": _make_id_token(signing_key, kid=None), "access_token": "at"}
+
+    user = asyncio.run(client.parse_id_token(token, nonce="n"))
+    assert user["sub"] == "user-42"
+
+
+def test_async_try_all_keys_with_kid_mismatch():
+    """With should_try_all_keys enabled, fallback finds correct key."""
+    signing_key = OctKey.import_key("secret-for-async-try-all")
+    key_dict = signing_key.as_dict()
+    key_dict["kid"] = "wrong-kid"
+    wrong_key = OctKey.import_key("wrong-async-key-material")
+    wrong_dict = wrong_key.as_dict()
+    wrong_dict["kid"] = "wrong-kid-2"
+    jwks = {"keys": [key_dict, wrong_dict]}
+    client = FakeAsyncClient(jwks, jwks_uri="https://issuer.test/jwks")
+    client.should_try_all_keys = lambda: True
+    token = {"id_token": _make_id_token(signing_key, kid="nonexistent-kid"), "access_token": "at"}
+
+    user = asyncio.run(client.parse_id_token(token, nonce="n"))
+    assert user["sub"] == "user-42"
+
+
+def test_async_try_all_keys_when_jwks_key_has_no_kid():
+    """With should_try_all_keys enabled, works when JWKS keys lack kid."""
+    signing_key = OctKey.import_key("secret-for-async-no-kid-jwks")
+    wrong_key = OctKey.import_key("wrong-async-no-kid-key")
+    # JWKS keys have no kid — triggers InvalidKeyIdError for token with kid
+    jwks = {"keys": [wrong_key.as_dict(), signing_key.as_dict()]}
+    client = FakeAsyncClient(jwks, jwks_uri="https://issuer.test/jwks")
+    client.should_try_all_keys = lambda: True
+    token = {"id_token": _make_id_token(signing_key, kid="token-kid"), "access_token": "at"}
+
+    user = asyncio.run(client.parse_id_token(token, nonce="n"))
+    assert user["sub"] == "user-42"
+
+
+def test_async_key_rotation_via_refresh():
+    """JWKS refresh resolves kid mismatch from key rotation."""
+    signing_key = OctKey.import_key("secret-for-async-rotation")
+    old_key = OctKey.import_key("old-key-material-xxxxxxx")
+    old_dict = old_key.as_dict()
+    old_dict["kid"] = "old-kid"
+    old_key2 = OctKey.import_key("old-key-material-zzzzzzz")
+    old_dict2 = old_key2.as_dict()
+    old_dict2["kid"] = "old-kid-2"
+
+    correct_dict = signing_key.as_dict()
+    correct_dict["kid"] = "new-kid"
+
+    client = FakeAsyncClient(
+        {"keys": [old_dict, old_dict2]},
+        jwks_uri="https://issuer.test/jwks",
+        refreshed_jwks={"keys": [correct_dict, old_dict2]},
+    )
+    token = {"id_token": _make_id_token(signing_key, kid="new-kid"), "access_token": "at"}
+
+    user = asyncio.run(client.parse_id_token(token, nonce="n"))
+    assert user["sub"] == "user-42"


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This is a feature implementation that adds a configurable fallback for OIDC ID token verification when the token's `kid` header does not match any key in the provider's JWKS.

**What is the current behavior?**

When `jwt.decode()` raises `InvalidKeyIdError`, the code refreshes the JWKS and retries. If the kid still does not match after refresh, `InvalidKeyIdError` is raised with no way to recover. This breaks integration with OIDC providers whose JWKS keys lack a `kid` field or use `kid` values that do not match the token header.

**What is the new behavior?**

On `InvalidKeyIdError`:
1. Refresh JWKS via `fetch_jwk_set(force=True)` to handle key rotation
2. Retry kid-based decode with refreshed keyset
3. If `should_try_all_keys()` returns `True`, try each key individually; otherwise re-raise `InvalidKeyIdError` (default, backwards-compatible)

Subclasses can override `should_try_all_keys()` to enable the brute-force fallback:
```python
class MyOAuth(OAuth):
    def should_try_all_keys(self):
        return True
```

**Checklist**

- [x] The commits follow the [conventional commits](https://www.conventionalcommits.org) specification.
- [x] You ran the linters with ``prek``.
- [x] You wrote unit test to demonstrate the bug you are fixing, or to stress the feature you are bringing.
- [x] You reached 100% of code coverage on the code you edited, without abusive use of `pragma: no cover`
- [ ] If this PR is about a new feature, or a behavior change, you have updated the documentation accordingly.

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.