### PR TITLE
feat: add should_handle hook for JWT client auth algorithm routing

### DIFF
--- a/authlib/oauth2/rfc7523/client.py
+++ b/authlib/oauth2/rfc7523/client.py
@@ -46,6 +46,8 @@ class JWTBearerClientAssertion:
         assertion = data.get("client_assertion")
         if assertion_type == ASSERTION_TYPE and assertion:
             headers, claims = self.extract_assertion(assertion)
+            if not self.should_handle(headers, claims):
+                return None
             client_id = claims["sub"]
             client = query_client(client_id)
             if not client:
@@ -135,6 +137,36 @@ class JWTBearerClientAssertion:
         raise InvalidClientError(
             description=f"The client cannot authenticate with method: {self.CLIENT_AUTH_METHOD}"
         )
+
+    def should_handle(self, headers: dict, claims: dict) -> bool:
+        """Determine whether this auth method should handle the given assertion.
+
+        Subclasses can override this to route JWT assertions by algorithm,
+        enabling separate handlers for symmetric and asymmetric auth methods.
+
+        When multiple JWT-based auth methods are registered, the dispatch loop
+        calls each handler in order. Returning False makes this handler yield
+        to the next one::
+
+            SYMMETRIC_ALGS = {"HS256", "HS384", "HS512"}
+
+            class ClientSecretJWTAuth(JWTBearerClientAssertion):
+                CLIENT_AUTH_METHOD = "client_secret_jwt"
+
+                def should_handle(self, headers, claims):
+                    return headers.get("alg") in SYMMETRIC_ALGS
+
+            class PrivateKeyJWTAuth(JWTBearerClientAssertion):
+                CLIENT_AUTH_METHOD = "private_key_jwt"
+
+                def should_handle(self, headers, claims):
+                    return headers.get("alg") not in SYMMETRIC_ALGS
+
+        :param headers: The JWT header dict (contains 'alg', 'typ', etc.)
+        :param claims: The JWT payload claims dict
+        :return: True if this handler should process the assertion
+        """
+        return True
 
     def extract_assertion(self, assertion: str):
         obj = jws.extract_compact(to_bytes(assertion))

--- a/tests/flask/test_oauth2/test_jwt_client_auth_routing.py
+++ b/tests/flask/test_oauth2/test_jwt_client_auth_routing.py
@@ -1,0 +1,119 @@
+"""Test should_handle hook in JWTBearerClientAssertion."""
+import time
+from unittest.mock import MagicMock
+
+from joserfc import jwt
+from joserfc.jwk import OctKey, RSAKey
+
+from authlib.oauth2.rfc7523 import JWTBearerClientAssertion
+from authlib.oauth2.rfc7523.client import ASSERTION_TYPE
+
+TOKEN_URL = "https://provider.test/oauth/token"
+SYMMETRIC_ALGS = {"HS256", "HS384", "HS512"}
+
+
+class ClientSecretJWTAuth(JWTBearerClientAssertion):
+    CLIENT_AUTH_METHOD = "client_secret_jwt"
+
+    def should_handle(self, headers, claims):
+        return headers.get("alg") in SYMMETRIC_ALGS
+
+    def get_audiences(self):
+        return [TOKEN_URL]
+
+    def validate_jti(self, claims, jti):
+        return True
+
+    def resolve_client_public_key(self, client):
+        return client.symmetric_key
+
+
+class PrivateKeyJWTAuth(JWTBearerClientAssertion):
+    CLIENT_AUTH_METHOD = "private_key_jwt"
+
+    def should_handle(self, headers, claims):
+        return headers.get("alg") not in SYMMETRIC_ALGS
+
+    def get_audiences(self):
+        return [TOKEN_URL]
+
+    def validate_jti(self, claims, jti):
+        return True
+
+    def resolve_client_public_key(self, client):
+        return client.public_key
+
+
+def _make_request(alg, key, client_id="test-client"):
+    now = int(time.time())
+    assertion = jwt.encode(
+        {"alg": alg},
+        {
+            "iss": client_id,
+            "sub": client_id,
+            "aud": TOKEN_URL,
+            "exp": now + 3600,
+            "jti": "test-jti",
+        },
+        key,
+    )
+    req = MagicMock()
+    req.form = {
+        "client_assertion_type": ASSERTION_TYPE,
+        "client_assertion": assertion,
+    }
+    return req
+
+
+def _make_client(symmetric_key=None, public_key=None):
+    client = MagicMock()
+    client.symmetric_key = symmetric_key
+    client.public_key = public_key
+    client.check_endpoint_auth_method.return_value = True
+    return client
+
+
+def test_client_secret_jwt_accepts_hs256():
+    """client_secret_jwt handler accepts and verifies HS256 assertion."""
+    oct_key = OctKey.import_key("secret-for-accept-test-xx")
+    client = _make_client(symmetric_key=oct_key)
+    auth = ClientSecretJWTAuth()
+    result = auth(lambda cid: client, _make_request(alg="HS256", key=oct_key))
+    assert result == client
+
+
+def test_client_secret_jwt_skips_rs256():
+    """client_secret_jwt handler returns None for RS256."""
+    rsa_key = RSAKey.generate_key(2048)
+    public_key = RSAKey.import_key(rsa_key.as_dict(private=False))
+    client = _make_client(public_key=public_key)
+    auth = ClientSecretJWTAuth()
+    result = auth(lambda cid: client, _make_request(alg="RS256", key=rsa_key))
+    assert result is None
+
+
+def test_private_key_jwt_accepts_rs256():
+    """private_key_jwt handler accepts and verifies RS256 assertion."""
+    rsa_key = RSAKey.generate_key(2048)
+    public_key = RSAKey.import_key(rsa_key.as_dict(private=False))
+    client = _make_client(public_key=public_key)
+    auth = PrivateKeyJWTAuth()
+    result = auth(lambda cid: client, _make_request(alg="RS256", key=rsa_key))
+    assert result == client
+
+
+def test_private_key_jwt_skips_hs256():
+    """private_key_jwt handler returns None for HS256."""
+    oct_key = OctKey.import_key("secret-for-skip-test-xxx")
+    client = _make_client(symmetric_key=oct_key)
+    auth = PrivateKeyJWTAuth()
+    result = auth(lambda cid: client, _make_request(alg="HS256", key=oct_key))
+    assert result is None
+
+
+def test_default_should_handle_accepts_all():
+    """Base class should_handle returns True for any algorithm."""
+    auth = JWTBearerClientAssertion()
+    assert auth.should_handle({"alg": "HS256"}, {"sub": "c1"}) is True
+    assert auth.should_handle({"alg": "RS256"}, {"sub": "c1"}) is True
+    assert auth.should_handle({"alg": "ES256"}, {"sub": "c1"}) is True


### PR DESCRIPTION
## What kind of change does this PR introduce?

This is a feature implementation.

## Description

Add a `should_handle(headers, claims)` method to `JWTBearerClientAssertion` that subclasses can override to filter JWT assertions by algorithm type. This enables registering separate handlers for `client_secret_jwt` (symmetric) and `private_key_jwt` (asymmetric) on the same authorization server.

When both auth methods use the same `client_assertion_type` (`urn:ietf:params:oauth:client-assertion-type:jwt-bearer`), the server must inspect the JWT `alg` header to route to the correct handler. Without this hook, the first registered handler may attempt verification with the wrong key type and raise `InvalidClientError`, preventing the correct handler from being tried.

Usage:
```python
SYMMETRIC_ALGS = {"HS256", "HS384", "HS512"}

class ClientSecretJWTAuth(JWTBearerClientAssertion):
    CLIENT_AUTH_METHOD = "client_secret_jwt"

    def should_handle(self, headers, claims):
        return headers.get("alg") in SYMMETRIC_ALGS

class PrivateKeyJWTAuth(JWTBearerClientAssertion):
    CLIENT_AUTH_METHOD = "private_key_jwt"

    def should_handle(self, headers, claims):
        return headers.get("alg") not in SYMMETRIC_ALGS
```

The default `should_handle()` returns `True`, maintaining full backward compatibility.

**Checklist**

- [x] The commits follow the [conventional commits](https://www.conventionalcommits.org) specification.
- [x] You ran the linters with ``prek``.
- [x] You wrote unit test to demonstrate the bug you are fixing, or to stress the feature you are bringing.
- [x] You reached 100% of code coverage on the code you edited, without abusive use of `pragma: no cover`
- [ ] If this PR is about a new feature, or a behavior change, you have updated the documentation accordingly.

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.