### PR TITLE
feat: auto-fetch token for client_credentials grant in OAuth2Session/OAuth2Client

### DIFF
--- a/authlib/integrations/httpx_client/oauth2_client.py
+++ b/authlib/integrations/httpx_client/oauth2_client.py
@@ -14,7 +14,6 @@ from authlib.oauth2.auth import TokenAuth
 from authlib.oauth2.client import OAuth2Client as _OAuth2Client
 
 from ..base_client import InvalidTokenError
-from ..base_client import MissingTokenError
 from ..base_client import OAuthError
 from ..base_client import UnsupportedTokenTypeError
 from .utils import HTTPX_CLIENT_KWARGS
@@ -109,11 +108,7 @@ class AsyncOAuth2Client(_OAuth2Client, httpx.AsyncClient):
         self, method, url, withhold_token=False, auth=USE_CLIENT_DEFAULT, **kwargs
     ):
         if not withhold_token and auth is USE_CLIENT_DEFAULT:
-            if not self.token:
-                raise MissingTokenError()
-
-            await self.ensure_active_token(self.token)
-
+            await self.ensure_active_token()
             auth = self.token_auth
 
         return await super().request(method, url, auth=auth, **kwargs)
@@ -123,17 +118,32 @@ class AsyncOAuth2Client(_OAuth2Client, httpx.AsyncClient):
         self, method, url, withhold_token=False, auth=USE_CLIENT_DEFAULT, **kwargs
     ):
         if not withhold_token and auth is USE_CLIENT_DEFAULT:
-            if not self.token:
-                raise MissingTokenError()
-
-            await self.ensure_active_token(self.token)
-
+            await self.ensure_active_token()
             auth = self.token_auth
 
         async with super().stream(method, url, auth=auth, **kwargs) as resp:
             yield resp
 
-    async def ensure_active_token(self, token):
+    async def ensure_active_token(self, token=None):
+        if token is None:
+            if not self.token:
+                if self.metadata.get("grant_type") == "client_credentials":
+                    await self.fetch_token()
+                else:
+                    # Lazy import to avoid circular dependency:
+                    #   authlib/oauth2/client.py
+                    #     → authlib/integrations/base_client/__init__.py (imports sync_openid)
+                    #       → authlib/integrations/base_client/sync_openid.py (imports authlib.oidc.core)
+                    #         → authlib/oidc/core/__init__.py (imports .grants)
+                    #           → authlib/oidc/core/grants/__init__.py (imports .code)
+                    #             → authlib/oidc/core/grants/code.py (imports ._legacy)
+                    #               → authlib/oidc/core/grants/_legacy.py (imports authlib.oauth2)
+                    #                 → authlib/oauth2/__init__.py (imports .client) → CIRCULAR
+                    # Python triggers __init__.py even when importing a submodule directly.
+                    from authlib.integrations.base_client.errors import MissingTokenError
+
+                    raise MissingTokenError()
+            token = self.token
         async with self._token_refresh_lock:
             if self.token.is_expired(leeway=self.leeway):
                 refresh_token = token.get("refresh_token")
@@ -260,10 +270,7 @@ class OAuth2Client(_OAuth2Client, httpx.Client):
         self, method, url, withhold_token=False, auth=USE_CLIENT_DEFAULT, **kwargs
     ):
         if not withhold_token and auth is USE_CLIENT_DEFAULT:
-            if not self.token:
-                raise MissingTokenError()
-
-            if not self.ensure_active_token(self.token):
+            if not self.ensure_active_token():
                 raise InvalidTokenError()
 
             auth = self.token_auth
@@ -274,10 +281,7 @@ class OAuth2Client(_OAuth2Client, httpx.Client):
         self, method, url, withhold_token=False, auth=USE_CLIENT_DEFAULT, **kwargs
     ):
         if not withhold_token and auth is USE_CLIENT_DEFAULT:
-            if not self.token:
-                raise MissingTokenError()
-
-            if not self.ensure_active_token(self.token):
+            if not self.ensure_active_token():
                 raise InvalidTokenError()
 
             auth = self.token_auth

--- a/authlib/integrations/requests_client/oauth2_session.py
+++ b/authlib/integrations/requests_client/oauth2_session.py
@@ -6,7 +6,6 @@ from authlib.oauth2.auth import TokenAuth
 from authlib.oauth2.client import OAuth2Client
 
 from ..base_client import InvalidTokenError
-from ..base_client import MissingTokenError
 from ..base_client import OAuthError
 from ..base_client import UnsupportedTokenTypeError
 from .utils import update_session_configure
@@ -134,7 +133,5 @@ class OAuth2Session(OAuth2Client, Session):
         if self.default_timeout:
             kwargs.setdefault("timeout", self.default_timeout)
         if not withhold_token and auth is None:
-            if not self.token:
-                raise MissingTokenError()
             auth = self.token_auth
         return super().request(method, url, auth=auth, **kwargs)

--- a/authlib/oauth2/client.py
+++ b/authlib/oauth2/client.py
@@ -300,6 +300,23 @@ class OAuth2Client:
 
     def ensure_active_token(self, token=None):
         if token is None:
+            if not self.token:
+                if self.metadata.get("grant_type") == "client_credentials":
+                    self.fetch_token()
+                else:
+                    # Lazy import to avoid circular dependency:
+                    #   authlib/oauth2/client.py (this file)
+                    #     → authlib/integrations/base_client/__init__.py (imports sync_openid)
+                    #       → authlib/integrations/base_client/sync_openid.py (imports authlib.oidc.core)
+                    #         → authlib/oidc/core/__init__.py (imports .grants)
+                    #           → authlib/oidc/core/grants/__init__.py (imports .code)
+                    #             → authlib/oidc/core/grants/code.py (imports ._legacy)
+                    #               → authlib/oidc/core/grants/_legacy.py (imports authlib.oauth2)
+                    #                 → authlib/oauth2/__init__.py (imports .client) → CIRCULAR
+                    # Python triggers __init__.py even when importing a submodule directly.
+                    from authlib.integrations.base_client.errors import MissingTokenError
+
+                    raise MissingTokenError()
             token = self.token
         if not token.is_expired(leeway=self.leeway):
             return True

--- a/tests/clients/test_httpx/test_async_oauth2_client.py
+++ b/tests/clients/test_httpx/test_async_oauth2_client.py
@@ -445,3 +445,66 @@ async def test_request_without_token():
     async with AsyncOAuth2Client("a", transport=transport) as client:
         with pytest.raises(OAuthError):
             await client.get("https://provider.test/token")
+
+
+@pytest.mark.asyncio
+async def test_client_credentials_auto_fetch_token_on_first_request():
+    transport = ASGITransport(AsyncMockDispatch(default_token))
+    async with AsyncOAuth2Client(
+        "foo",
+        client_secret="bar",
+        token_endpoint="https://provider.test/token",
+        grant_type="client_credentials",
+        transport=transport,
+    ) as client:
+        await client.get("https://provider.test/resource")
+        assert client.token["access_token"] == default_token["access_token"]
+
+
+@pytest.mark.asyncio
+async def test_non_client_credentials_raises_missing_token():
+    transport = ASGITransport(AsyncMockDispatch())
+    async with AsyncOAuth2Client("foo", transport=transport) as client:
+        with pytest.raises(OAuthError):
+            await client.get("https://provider.test/resource")
+
+
+@pytest.mark.asyncio
+async def test_client_credentials_auto_fetch_token_on_first_stream():
+    transport = ASGITransport(AsyncMockDispatch(default_token))
+    async with AsyncOAuth2Client(
+        "foo",
+        client_secret="bar",
+        token_endpoint="https://provider.test/token",
+        grant_type="client_credentials",
+        transport=transport,
+    ) as client:
+        async with client.stream("GET", "https://provider.test/resource") as stream:
+            await stream.aread()
+        assert client.token["access_token"] == default_token["access_token"]
+
+
+@pytest.mark.asyncio
+async def test_non_client_credentials_raises_missing_token_on_stream():
+    transport = ASGITransport(AsyncMockDispatch())
+    async with AsyncOAuth2Client("foo", transport=transport) as client:
+        with pytest.raises(OAuthError):
+            async with client.stream("GET", "https://provider.test/resource") as stream:
+                await stream.aread()
+
+
+@pytest.mark.asyncio
+async def test_ensure_active_token_with_provided_token():
+    transport = ASGITransport(AsyncMockDispatch(default_token))
+    async with AsyncOAuth2Client(
+        "foo",
+        token_endpoint="https://provider.test/token",
+        grant_type="client_credentials",
+        transport=transport,
+    ) as client:
+        token = deepcopy(default_token)
+        token["expires_at"] = time.time() + 3600
+        client.token = token
+        with mock.patch.object(client, "fetch_token") as mocked:
+            await client.ensure_active_token(token)
+            mocked.assert_not_called()

--- a/tests/clients/test_httpx/test_oauth2_client.py
+++ b/tests/clients/test_httpx/test_oauth2_client.py
@@ -369,3 +369,45 @@ def test_request_without_token():
     with OAuth2Client("a", transport=transport) as client:
         with pytest.raises(OAuthError):
             client.get("https://provider.test/token")
+
+
+def test_client_credentials_auto_fetch_token_on_first_request():
+    transport = WSGITransport(MockDispatch(default_token))
+    with OAuth2Client(
+        "foo",
+        client_secret="bar",
+        token_endpoint="https://provider.test/token",
+        grant_type="client_credentials",
+        transport=transport,
+    ) as client:
+        client.get("https://provider.test/resource")
+        assert client.token["access_token"] == default_token["access_token"]
+
+
+def test_non_client_credentials_raises_missing_token():
+    transport = WSGITransport(MockDispatch())
+    with OAuth2Client("foo", transport=transport) as client:
+        with pytest.raises(OAuthError):
+            client.get("https://provider.test/resource")
+
+
+def test_client_credentials_auto_fetch_token_on_first_stream():
+    transport = WSGITransport(MockDispatch(default_token))
+    with OAuth2Client(
+        "foo",
+        client_secret="bar",
+        token_endpoint="https://provider.test/token",
+        grant_type="client_credentials",
+        transport=transport,
+    ) as client:
+        with client.stream("GET", "https://provider.test/resource") as stream:
+            stream.read()
+        assert client.token["access_token"] == default_token["access_token"]
+
+
+def test_non_client_credentials_raises_missing_token_on_stream():
+    transport = WSGITransport(MockDispatch())
+    with OAuth2Client("foo", transport=transport) as client:
+        with pytest.raises(OAuthError):
+            with client.stream("GET", "https://provider.test/resource") as stream:
+                stream.read()

--- a/tests/clients/test_requests/test_oauth2_session.py
+++ b/tests/clients/test_requests/test_oauth2_session.py
@@ -620,3 +620,32 @@ def test_override_default_request_timeout(token):
     client.request(
         "GET", "https://provider.test", withhold_token=False, timeout=expected_timeout
     )
+
+
+def test_client_credentials_auto_fetch_token_on_first_request(token):
+    url = "https://provider.test/token"
+
+    def fake_send(r, **kwargs):
+        resp = mock.MagicMock()
+        resp.status_code = 200
+        if "grant_type=client_credentials" in (r.body or ""):
+            resp.json = lambda: token
+        return resp
+
+    sess = OAuth2Session(
+        client_id="foo",
+        client_secret="bar",
+        token_endpoint=url,
+        grant_type="client_credentials",
+    )
+    sess.send = fake_send
+    sess.get("https://provider.test/resource")
+    assert sess.token["access_token"] == token["access_token"]
+
+
+def test_non_client_credentials_raises_missing_token():
+    from authlib.integrations.base_client import MissingTokenError
+
+    sess = OAuth2Session(client_id="foo")
+    with pytest.raises(MissingTokenError):
+        sess.get("https://provider.test/resource")


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This is a feature implementation.

When using `OAuth2Session` (requests) or `OAuth2Client` (httpx) with the `client_credentials` grant type, the caller must explicitly call `fetch_token()` before making any resource request, even though all the required metadata (`token_endpoint`, `grant_type`, `client_id`, `client_secret`) is already configured on the session. This is inconsistent with `AssertionSession`, which transparently auto-fetches tokens via `ensure_active_token()`.

Before:

```python
from authlib.integrations.requests_client import OAuth2Session

sess = OAuth2Session(
    client_id="my-client",
    client_secret="my-secret",
    token_endpoint="https://auth.example.com/token",
    grant_type="client_credentials",
)

# Must manually fetch before any request — raises MissingTokenError otherwise
sess.fetch_token("https://auth.example.com/token")
resp = sess.get("https://api.example.com/resource")
```

After:

```python
from authlib.integrations.requests_client import OAuth2Session

sess = OAuth2Session(
    client_id="my-client",
    client_secret="my-secret",
    token_endpoint="https://auth.example.com/token",
    grant_type="client_credentials",
)

# Token is fetched automatically on first request
resp = sess.get("https://api.example.com/resource")
```

Solution: In `request()` (and `stream()` for httpx), when `self.token` is `None` and the configured `grant_type` is `"client_credentials"`, call `self.fetch_token()` automatically. Since `fetch_token()` already reads `token_endpoint` and `grant_type` from `self.metadata` when not explicitly provided, the call is simply `self.fetch_token()` with no arguments needed.

For non-`client_credentials` grant types, the existing `MissingTokenError` / `OAuthError` behavior is preserved unchanged.

Fully backward compatible — sessions that already call `fetch_token()` explicitly continue to work identically.

**Checklist**

- [x] The commits follow the [conventional commits](https://www.conventionalcommits.org) specification.
- [x] You ran the linters with `prek`.
- [x] You wrote unit test to demonstrate the bug you are fixing, or to stress the feature you are bringing.
- [x] You reached 100% of code coverage on the code you edited, without abusive use of `pragma: no cover`
- [ ] If this PR is about a new feature, or a behavior change, you have updated the documentation accordingly.

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.