### PR TITLE
feat: add token_endpoint_verify for custom CA on token requests

### DIFF
--- a/authlib/integrations/httpx_client/assertion_client.py
+++ b/authlib/integrations/httpx_client/assertion_client.py
@@ -78,6 +78,10 @@ class AssertionClient(_AssertionClient, httpx.Client):
     }
     DEFAULT_GRANT_TYPE = JWT_BEARER_GRANT_TYPE
 
+    def _apply_token_endpoint_kwargs(self, kwargs):
+        # httpx does not support per-request verify; it's set at client level.
+        pass
+
     def __init__(
         self,
         token_endpoint,

--- a/authlib/integrations/httpx_client/oauth2_client.py
+++ b/authlib/integrations/httpx_client/oauth2_client.py
@@ -67,6 +67,10 @@ class AsyncOAuth2Client(_OAuth2Client, httpx.AsyncClient):
     token_auth_class = OAuth2Auth
     oauth_error_class = OAuthError
 
+    def _apply_token_endpoint_kwargs(self, session_kwargs):
+        # httpx does not support per-request verify; it's set at client level.
+        pass
+
     def __init__(
         self,
         client_id=None,
@@ -214,6 +218,10 @@ class OAuth2Client(_OAuth2Client, httpx.Client):
     client_auth_class = OAuth2ClientAuth
     token_auth_class = OAuth2Auth
     oauth_error_class = OAuthError
+
+    def _apply_token_endpoint_kwargs(self, session_kwargs):
+        # httpx does not support per-request verify; it's set at client level.
+        pass
 
     def __init__(
         self,

--- a/authlib/oauth2/client.py
+++ b/authlib/oauth2/client.py
@@ -38,6 +38,14 @@ class OAuth2Client:
         values: "header", "body", "uri".
     :param update_token: A function for you to update token. It accept a
         :class:`OAuth2Token` as parameter.
+    :param token_endpoint_verify: SSL verification for token endpoint requests.
+        Defaults to ``None``, which means the session's default verify setting
+        is used (same as resource requests). Set to a CA bundle path to use a
+        custom certificate, ``True`` to use the default CA bundle, or ``False``
+        to disable verification. When not ``None``, it applies only to
+        ``fetch_token`` and ``refresh_token`` requests without affecting
+        resource requests. Only works with the requests integration (httpx
+        uses client-level verify).
     :param leeway: Time window in seconds before the actual expiration of the
         authentication token, that the token is considered expired and will
         be refreshed.
@@ -64,6 +72,7 @@ class OAuth2Client:
         token=None,
         token_placement="header",
         update_token=None,
+        token_endpoint_verify=None,
         leeway=60,
         **metadata,
     ):
@@ -101,6 +110,7 @@ class OAuth2Client:
                 "update token has been redesigned, checkout the documentation"
             )
 
+        self.token_endpoint_verify = token_endpoint_verify
         self.metadata = metadata
 
         self.compliance_hook = {
@@ -216,6 +226,7 @@ class OAuth2Client:
             return self.token_from_fragment(authorization_response, state)
 
         session_kwargs = self._extract_session_request_params(kwargs)
+        self._apply_token_endpoint_kwargs(session_kwargs)
 
         if authorization_response and "code=" in authorization_response:
             grant_type = "authorization_code"
@@ -270,6 +281,7 @@ class OAuth2Client:
         :return: A :class:`OAuth2Token` object (a dict too).
         """
         session_kwargs = self._extract_session_request_params(kwargs)
+        self._apply_token_endpoint_kwargs(session_kwargs)
         refresh_token = refresh_token or self.token.get("refresh_token")
         if "scope" not in kwargs and self.scope:
             kwargs["scope"] = self.scope
@@ -508,6 +520,10 @@ class OAuth2Client:
             if k in kwargs:
                 rv[k] = kwargs.pop(k)
         return rv
+
+    def _apply_token_endpoint_kwargs(self, session_kwargs):
+        """Apply token-endpoint-specific kwargs (e.g., verify) to session kwargs."""
+        session_kwargs.setdefault("verify", self.token_endpoint_verify)
 
     def _http_post(self, url, body=None, auth=None, headers=None, **kwargs):
         return self.session.post(

--- a/authlib/oauth2/rfc7521/client.py
+++ b/authlib/oauth2/rfc7521/client.py
@@ -25,6 +25,7 @@ class AssertionClient:
         claims=None,
         token_placement="header",
         scope=None,
+        token_endpoint_verify=None,
         leeway=60,
         **kwargs,
     ):
@@ -46,6 +47,7 @@ class AssertionClient:
         self.audience = audience
         self.claims = claims
         self.scope = scope
+        self.token_endpoint_verify = token_endpoint_verify
         if self.token_auth_class is not None:
             self.token_auth = self.token_auth_class(None, token_placement, self)
         self._kwargs = kwargs
@@ -95,9 +97,15 @@ class AssertionClient:
         self.token = token
         return self.token
 
+    def _apply_token_endpoint_kwargs(self, kwargs):
+        """Apply token-endpoint-specific kwargs (e.g., verify) to request kwargs."""
+        kwargs.setdefault("verify", self.token_endpoint_verify)
+
     def _refresh_token(self, data):
+        kwargs = {}
+        self._apply_token_endpoint_kwargs(kwargs)
         resp = self.session.request(
-            "POST", self.token_endpoint, data=data, withhold_token=True
+            "POST", self.token_endpoint, data=data, withhold_token=True, **kwargs
         )
 
         return self.parse_response_token(resp)

--- a/tests/clients/test_httpx/test_assertion_client.py
+++ b/tests/clients/test_httpx/test_assertion_client.py
@@ -63,3 +63,19 @@ def test_without_alg():
     ) as client:
         with pytest.raises(ValueError):
             client.get("https://provider.test")
+
+
+def test_token_endpoint_verify_does_not_crash_httpx():
+    """token_endpoint_verify is accepted but ignored for httpx (client-level verify only)."""
+    with AssertionClient(
+        "https://provider.test/token",
+        issuer="foo",
+        subject="foo",
+        audience="foo",
+        alg="HS256",
+        key="secret",
+        token_endpoint_verify="/path/to/ca.pem",
+        transport=WSGITransport(MockDispatch(default_token)),
+    ) as client:
+        client.get("https://provider.test")
+        assert client.token["access_token"] == "a"

--- a/tests/clients/test_httpx/test_async_assertion_client.py
+++ b/tests/clients/test_httpx/test_async_assertion_client.py
@@ -66,3 +66,20 @@ async def test_without_alg():
     ) as client:
         with pytest.raises(ValueError):
             await client.get("https://provider.test")
+
+
+@pytest.mark.asyncio
+async def test_token_endpoint_verify_does_not_crash_httpx():
+    """token_endpoint_verify is accepted but ignored for httpx (client-level verify only)."""
+    async with AsyncAssertionClient(
+        "https://provider.test/token",
+        issuer="foo",
+        subject="foo",
+        audience="foo",
+        alg="HS256",
+        key="secret",
+        token_endpoint_verify="/path/to/ca.pem",
+        transport=ASGITransport(AsyncMockDispatch(default_token)),
+    ) as client:
+        await client.get("https://provider.test")
+        assert client.token["access_token"] == "a"

--- a/tests/clients/test_httpx/test_async_oauth2_client.py
+++ b/tests/clients/test_httpx/test_async_oauth2_client.py
@@ -445,3 +445,18 @@ async def test_request_without_token():
     async with AsyncOAuth2Client("a", transport=transport) as client:
         with pytest.raises(OAuthError):
             await client.get("https://provider.test/token")
+
+
+@pytest.mark.asyncio
+async def test_token_endpoint_verify_does_not_crash_httpx():
+    """token_endpoint_verify is accepted but ignored for httpx (client-level verify only)."""
+    transport = ASGITransport(AsyncMockDispatch(default_token))
+    async with AsyncOAuth2Client(
+        "foo",
+        token_endpoint="https://provider.test/token",
+        grant_type="client_credentials",
+        token_endpoint_verify="/path/to/ca.pem",
+        transport=transport,
+    ) as client:
+        token = await client.fetch_token("https://provider.test/token")
+        assert token["access_token"] == "a"

--- a/tests/clients/test_httpx/test_oauth2_client.py
+++ b/tests/clients/test_httpx/test_oauth2_client.py
@@ -369,3 +369,17 @@ def test_request_without_token():
     with OAuth2Client("a", transport=transport) as client:
         with pytest.raises(OAuthError):
             client.get("https://provider.test/token")
+
+
+def test_token_endpoint_verify_does_not_crash_httpx():
+    """token_endpoint_verify is accepted but ignored for httpx (client-level verify only)."""
+    transport = WSGITransport(MockDispatch(default_token))
+    with OAuth2Client(
+        "foo",
+        token_endpoint="https://provider.test/token",
+        grant_type="client_credentials",
+        token_endpoint_verify="/path/to/ca.pem",
+        transport=transport,
+    ) as client:
+        token = client.fetch_token("https://provider.test/token")
+        assert token["access_token"] == "a"

--- a/tests/clients/test_requests/test_assertion_session.py
+++ b/tests/clients/test_requests/test_assertion_session.py
@@ -68,3 +68,70 @@ def test_without_alg():
     )
     with pytest.raises(ValueError):
         sess.get("https://provider.test")
+
+
+def test_token_endpoint_verify_passed_to_refresh_token():
+    ca_path = "/path/to/custom-ca.pem"
+    token = {
+        "token_type": "Bearer",
+        "access_token": "a",
+        "expires_in": "3600",
+    }
+    calls = []
+
+    def fake_send(r, **kwargs):
+        calls.append((r.url, kwargs.get("verify")))
+        resp = mock.MagicMock()
+        resp.status_code = 200
+        resp.json = lambda: token
+        return resp
+
+    now = int(time.time())
+    sess = AssertionSession(
+        "https://provider.test/token",
+        issuer="foo",
+        subject="foo",
+        audience="foo",
+        issued_at=now,
+        expires_at=now + 3600,
+        header={"alg": "HS256"},
+        key="secret",
+        token_endpoint_verify=ca_path,
+    )
+    sess.send = fake_send
+    sess.get("https://provider.test")
+    # First call is the token request — should use custom CA
+    assert calls[0] == ("https://provider.test/token", ca_path)
+
+
+def test_token_endpoint_verify_false_disables_verification():
+    token = {
+        "token_type": "Bearer",
+        "access_token": "a",
+        "expires_in": "3600",
+    }
+    calls = []
+
+    def fake_send(r, **kwargs):
+        calls.append((r.url, kwargs.get("verify")))
+        resp = mock.MagicMock()
+        resp.status_code = 200
+        resp.json = lambda: token
+        return resp
+
+    now = int(time.time())
+    sess = AssertionSession(
+        "https://provider.test/token",
+        issuer="foo",
+        subject="foo",
+        audience="foo",
+        issued_at=now,
+        expires_at=now + 3600,
+        header={"alg": "HS256"},
+        key="secret",
+        token_endpoint_verify=False,
+    )
+    sess.send = fake_send
+    sess.get("https://provider.test")
+    # Token request should have verify=False
+    assert calls[0] == ("https://provider.test/token", False)

--- a/tests/clients/test_requests/test_oauth2_session.py
+++ b/tests/clients/test_requests/test_oauth2_session.py
@@ -620,3 +620,142 @@ def test_override_default_request_timeout(token):
     client.request(
         "GET", "https://provider.test", withhold_token=False, timeout=expected_timeout
     )
+
+
+def test_token_endpoint_verify_passed_to_fetch_token(token):
+    ca_path = "/path/to/custom-ca.pem"
+
+    def fake_send(r, **kwargs):
+        assert kwargs.get("verify") == ca_path
+        resp = mock.MagicMock()
+        resp.status_code = 200
+        resp.json = lambda: token
+        return resp
+
+    sess = OAuth2Session(
+        client_id="foo",
+        client_secret="bar",
+        token_endpoint="https://provider.test/token",
+        grant_type="client_credentials",
+        token_endpoint_verify=ca_path,
+    )
+    sess.send = fake_send
+    sess.fetch_token()
+    assert sess.token["access_token"] == token["access_token"]
+
+
+def test_token_endpoint_verify_does_not_affect_resource_requests(token):
+    ca_path = "/path/to/custom-ca.pem"
+
+    def fake_send(r, **kwargs):
+        # Resource requests should NOT have the custom CA
+        assert kwargs.get("verify") != ca_path
+        resp = mock.MagicMock()
+        resp.status_code = 200
+        resp.json = lambda: {}
+        return resp
+
+    sess = OAuth2Session(
+        client_id="foo",
+        token=token,
+        token_endpoint_verify=ca_path,
+    )
+    sess.send = fake_send
+    sess.get("https://provider.test/resource")
+
+
+def test_token_endpoint_verify_explicit_verify_kwarg_takes_precedence(token):
+    ca_path = "/path/to/custom-ca.pem"
+    override_path = "/path/to/override-ca.pem"
+
+    def fake_send(r, **kwargs):
+        assert kwargs.get("verify") == override_path
+        resp = mock.MagicMock()
+        resp.status_code = 200
+        resp.json = lambda: token
+        return resp
+
+    sess = OAuth2Session(
+        client_id="foo",
+        client_secret="bar",
+        token_endpoint="https://provider.test/token",
+        grant_type="client_credentials",
+        token_endpoint_verify=ca_path,
+    )
+    sess.send = fake_send
+    sess.fetch_token(verify=override_path)
+
+
+def test_token_endpoint_verify_passed_to_refresh_token(token):
+    ca_path = "/path/to/custom-ca.pem"
+    refreshed_token = {
+        "token_type": "Bearer",
+        "access_token": "refreshed",
+        "refresh_token": "new_rt",
+        "expires_in": 3600,
+    }
+
+    def fake_send(r, **kwargs):
+        assert kwargs.get("verify") == ca_path
+        resp = mock.MagicMock()
+        resp.status_code = 200
+        resp.json = lambda: refreshed_token
+        return resp
+
+    # Give the token an expired state
+    expired_token = deepcopy(token)
+    expired_token["expires_at"] = time.time() - 100
+
+    sess = OAuth2Session(
+        client_id="foo",
+        client_secret="bar",
+        token_endpoint="https://provider.test/token",
+        token_endpoint_verify=ca_path,
+        token=expired_token,
+    )
+    sess.send = fake_send
+    sess.refresh_token("https://provider.test/token")
+    assert sess.token["access_token"] == "refreshed"
+
+
+def test_token_endpoint_verify_false_disables_verification(token):
+    def fake_send(r, **kwargs):
+        assert kwargs.get("verify") is False
+        resp = mock.MagicMock()
+        resp.status_code = 200
+        resp.json = lambda: token
+        return resp
+
+    sess = OAuth2Session(
+        client_id="foo",
+        client_secret="bar",
+        token_endpoint="https://provider.test/token",
+        grant_type="client_credentials",
+        token_endpoint_verify=False,
+    )
+    sess.send = fake_send
+    sess.fetch_token()
+    assert sess.token["access_token"] == token["access_token"]
+
+
+def test_token_endpoint_verify_none_uses_session_default(token):
+    def fake_send(r, **kwargs):
+        # When token_endpoint_verify is None, no extra verify kwarg is injected;
+        # the session's own verify setting is used (requests.Session.verify
+        # defaults to True).
+        assert kwargs.get("verify") is True
+        resp = mock.MagicMock()
+        resp.status_code = 200
+        resp.json = lambda: token
+        return resp
+
+    sess = OAuth2Session(
+        client_id="foo",
+        client_secret="bar",
+        token_endpoint="https://provider.test/token",
+        grant_type="client_credentials",
+        # token_endpoint_verify defaults to None
+    )
+    sess.send = fake_send
+    sess.fetch_token()
+    assert sess.token["access_token"] == token["access_token"]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature implementation.

## What is the current behavior?

When fetching or refreshing an OAuth2 access token, the TLS `verify` setting uses the same value as regular resource requests (session-level `verify`). There is no way to specify a different CA certificate bundle specifically for the token endpoint.

This is problematic when the token endpoint uses a different certificate chain (e.g., an internal CA) than the resource endpoints.

## What is the new behavior?

A new `token_endpoint_verify` parameter is available on both `OAuth2Session` (via `OAuth2Client`) and `AssertionSession` (via `AssertionClient`). When set, it is used as the `verify` value for token endpoint requests (`fetch_token` and `refresh_token`), while regular resource requests remain unaffected.

### Before

```python
# No way to use a different CA for the token endpoint
sess = OAuth2Session(client_id="foo", client_secret="bar", ...)
sess.verify = "/path/to/resource-ca.pem"  # Applies to ALL requests
```

### After

```python
sess = OAuth2Session(
    client_id="foo",
    client_secret="bar",
    token_endpoint="https://idp.internal/token",
    grant_type="client_credentials",
    token_endpoint_verify="/path/to/idp-ca.pem",  # Only for token requests
)
sess.verify = "/path/to/resource-ca.pem"  # For resource requests
```

The same works for `AssertionSession`:

```python
sess = AssertionSession(
    "https://idp.internal/token",
    issuer="my-app",
    subject="my-app",
    audience="https://idp.internal/token",
    header={"alg": "RS256"},
    key=private_key,
    token_endpoint_verify="/path/to/idp-ca.pem",
)
```

If an explicit `verify` kwarg is passed to `fetch_token()`, it takes precedence over `token_endpoint_verify`.

## Notes

- This feature is primarily useful for the `requests` integration where `verify` is a per-request parameter.
- For the `httpx` integration, `verify` is a client-level setting (not per-request), so `token_endpoint_verify` is accepted but has no effect for httpx clients. A future enhancement could address this with a custom transport.


**Checklist**

- [x] The commits follow the [conventional commits](https://www.conventionalcommits.org) specification.
- [x] You ran the linters with ``prek``.
- [x] You wrote unit test to demonstrate the bug you are fixing, or to stress the feature you are bringing.
- [x] You reached 100% of code coverage on the code you edited, without abusive use of `pragma: no cover`
- [ ] If this PR is about a new feature, or a behavior change, you have updated the documentation accordingly.

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.