### PR TITLE
feat: add default jti claim to sign_jwt_bearer_assertion

### DIFF
--- a/authlib/oauth2/rfc7523/assertion.py
+++ b/authlib/oauth2/rfc7523/assertion.py
@@ -41,6 +41,12 @@ def sign_jwt_bearer_assertion(
     payload["iat"] = issued_at
     payload["exp"] = expires_at
 
+    if claims is None:
+        claims = {}
+    # jti uniquely identifies the JWT and prevents replay attacks (RFC 7523 §3)
+    if "jti" not in claims:
+        claims["jti"] = generate_token(36)
+
     if claims:
         payload.update(claims)
 

--- a/tests/clients/test_requests/test_assertion_session.py
+++ b/tests/clients/test_requests/test_assertion_session.py
@@ -1,7 +1,10 @@
 import time
+import urllib.parse
 from unittest import mock
 
 import pytest
+from joserfc import jwt
+from joserfc.jwk import OctKey
 
 from authlib.integrations.requests_client import AssertionSession
 
@@ -68,3 +71,99 @@ def test_without_alg():
     )
     with pytest.raises(ValueError):
         sess.get("https://provider.test")
+
+
+def test_assertion_includes_default_jti(token):
+    """Verify that AssertionSession generates a jti in the JWT assertion."""
+    assertions = []
+
+    def verifier(r, **kwargs):
+        resp = mock.MagicMock()
+        resp.status_code = 200
+        if r.url == "https://provider.test/token":
+            body = urllib.parse.parse_qs(r.body)
+            assertions.append(body["assertion"][0])
+            resp.json = lambda: token
+        return resp
+
+    sess = AssertionSession(
+        "https://provider.test/token",
+        issuer="foo",
+        subject="foo",
+        audience="foo",
+        alg="HS256",
+        key="secret",
+    )
+    sess.send = verifier
+    sess.get("https://provider.test")
+
+    assert len(assertions) == 1
+    key = OctKey.import_key("secret")
+    claims = jwt.decode(assertions[0], key).claims
+    assert "jti" in claims
+    assert len(claims["jti"]) == 36
+
+
+def test_assertion_jti_is_unique_per_refresh(token):
+    """Verify that each token refresh generates a new unique jti."""
+    assertions = []
+
+    def verifier(r, **kwargs):
+        resp = mock.MagicMock()
+        resp.status_code = 200
+        if r.url == "https://provider.test/token":
+            body = urllib.parse.parse_qs(r.body)
+            assertions.append(body["assertion"][0])
+            resp.json = lambda: {**token, "expires_in": "1", "expires_at": int(time.time()) - 1}
+        return resp
+
+    sess = AssertionSession(
+        "https://provider.test/token",
+        issuer="foo",
+        subject="foo",
+        audience="foo",
+        alg="HS256",
+        key="secret",
+    )
+    sess.send = verifier
+    sess.get("https://provider.test")
+    sess.get("https://provider.test")
+
+    assert len(assertions) == 2
+    key = OctKey.import_key("secret")
+    jti1 = jwt.decode(assertions[0], key).claims["jti"]
+    jti2 = jwt.decode(assertions[1], key).claims["jti"]
+    assert jti1
+    assert jti2
+    assert jti1 != jti2
+
+
+def test_assertion_custom_jti_is_preserved(token):
+    """Verify that a user-provided jti claim is not overwritten."""
+    assertions = []
+
+    def verifier(r, **kwargs):
+        resp = mock.MagicMock()
+        resp.status_code = 200
+        if r.url == "https://provider.test/token":
+            body = urllib.parse.parse_qs(r.body)
+            assertions.append(body["assertion"][0])
+            resp.json = lambda: token
+        return resp
+
+    sess = AssertionSession(
+        "https://provider.test/token",
+        issuer="foo",
+        subject="foo",
+        audience="foo",
+        alg="HS256",
+        key="secret",
+        claims={"jti": "my-custom-jti-value"},
+    )
+    sess.send = verifier
+    sess.get("https://provider.test")
+
+    assert len(assertions) == 1
+    key = OctKey.import_key("secret")
+    claims = jwt.decode(assertions[0], key).claims
+    assert claims["jti"] == "my-custom-jti-value"

--- a/tests/core/test_oauth2/test_rfc7523_assertion.py
+++ b/tests/core/test_oauth2/test_rfc7523_assertion.py
@@ -1,0 +1,54 @@
+from joserfc import jwt
+from joserfc.jwk import OctKey
+
+from authlib.oauth2.rfc7523.assertion import sign_jwt_bearer_assertion
+
+
+def decode(token, key="secret"):
+    return jwt.decode(token, OctKey.import_key(key)).claims
+
+
+def test_default_jti_is_generated():
+    token = sign_jwt_bearer_assertion(
+        key="secret", issuer="client1", audience="https://auth.example/token", alg="HS256"
+    )
+    claims = decode(token)
+    assert "jti" in claims
+    assert len(claims["jti"]) == 36
+
+
+def test_custom_jti_is_preserved():
+    token = sign_jwt_bearer_assertion(
+        key="secret",
+        issuer="client1",
+        audience="https://auth.example/token",
+        alg="HS256",
+        claims={"jti": "my-custom-jti"},
+    )
+    claims = decode(token)
+    assert claims["jti"] == "my-custom-jti"
+
+
+def test_each_call_generates_unique_jti():
+    tokens = [
+        sign_jwt_bearer_assertion(
+            key="secret", issuer="client1", audience="https://auth.example/token", alg="HS256"
+        )
+        for _ in range(5)
+    ]
+    jtis = [decode(t)["jti"] for t in tokens]
+    assert all(jtis)
+    assert len(set(jtis)) == 5
+
+
+def test_claims_with_other_fields_still_gets_jti():
+    token = sign_jwt_bearer_assertion(
+        key="secret",
+        issuer="client1",
+        audience="https://auth.example/token",
+        alg="HS256",
+        claims={"custom_field": "value"},
+    )
+    claims = decode(token)
+    assert claims["jti"]
+    assert claims["custom_field"] == "value"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature implementation.

## Summary

`sign_jwt_bearer_assertion()` (used by `AssertionSession` via `JWTBearerGrant.sign()`) did not generate a default `jti` (JWT ID) claim, unlike the `_sign()` helper used by `OAuth2Session` for client credentials (`client_secret_jwt_sign` / `private_key_jwt_sign`).

This meant that `AssertionSession` JWTs lacked replay-attack protection unless users manually added `jti` to claims. Many identity providers require `jti` to detect and reject replayed tokens.

## Changes

- **`authlib/oauth2/rfc7523/assertion.py`**: Add automatic `jti` generation (36-char random token via `generate_token`) in `sign_jwt_bearer_assertion()` when no `jti` is present in claims. A user-provided `jti` is preserved and not overwritten.
- **`tests/core/test_oauth2/test_rfc7523_assertion.py`**: New test file with 4 tests covering default jti generation, custom jti preservation, uniqueness, and coexistence with other claims.
- **`tests/clients/test_requests/test_assertion_session.py`**: 3 new integration tests verifying that `AssertionSession` token requests include jti, generate unique jti per refresh, and preserve custom jti.

## Rationale

Per [RFC 7523 §3](https://tools.ietf.org/html/rfc7523#section-3), the JWT ID (`jti`) uniquely identifies the token and enables replay detection. The `_sign()` helper (used for client authentication via `client_secret_jwt_sign` / `private_key_jwt_sign`) already had this behavior with the comment "jti is required". This PR brings `sign_jwt_bearer_assertion()` to parity.

**Checklist**

- [x] The commits follow the [conventional commits](https://www.conventionalcommits.org) specification.
- [x] You ran the linters with ``prek``.
- [x] You wrote unit test to demonstrate the bug you are fixing, or to stress the feature you are bringing.
- [x] You reached 100% of code coverage on the code you edited, without abusive use of `pragma: no cover`
- [ ] If this PR is about a new feature, or a behavior change, you have updated the documentation accordingly.

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.