### PR TITLE
fix: make leeway configurable in JWTBearerTokenValidator

### DIFF
--- a/authlib/oauth2/rfc7523/validator.py
+++ b/authlib/oauth2/rfc7523/validator.py
@@ -33,9 +33,10 @@ class JWTBearerTokenValidator(BearerTokenValidator):
     TOKEN_TYPE = "bearer"
     token_cls = JWTBearerToken
 
-    def __init__(self, public_key, issuer=None, realm=None, **extra_attributes):
+    def __init__(self, public_key, issuer=None, realm=None, leeway=60, **extra_attributes):
         super().__init__(realm, **extra_attributes)
         self.public_key = import_any_key(public_key)
+        self.leeway = leeway
         claims_options = {
             "exp": {"essential": True},
             "client_id": {"essential": True},
@@ -52,7 +53,7 @@ class JWTBearerTokenValidator(BearerTokenValidator):
             logger.debug("Authenticate token failed. %r", error)
             return None
 
-        claims_requests = jwt.JWTClaimsRegistry(leeway=60, **self.claims_options)
+        claims_requests = jwt.JWTClaimsRegistry(leeway=self.leeway, **self.claims_options)
         try:
             claims_requests.validate(token.claims)
         except JoseError as error:

--- a/tests/core/test_oauth2/test_rfc7523_validator.py
+++ b/tests/core/test_oauth2/test_rfc7523_validator.py
@@ -59,3 +59,20 @@ def test_expired_token(oct_key):
     time.sleep(0.1)
     with pytest.raises(InvalidTokenError):
         validator.validate_token(token, [], None)
+
+
+def test_custom_leeway(oct_key):
+    claims = {
+        "exp": int(time.time()) - 30,
+        "client_id": "client-id",
+        "grant_type": "client_credentials",
+    }
+    token_string = jwt.encode({"alg": "HS256"}, claims, oct_key)
+
+    validator_no_leeway = JWTBearerTokenValidator(oct_key, leeway=0)
+    token = validator_no_leeway.authenticate_token(token_string)
+    assert token is None
+
+    validator_with_leeway = JWTBearerTokenValidator(oct_key, leeway=60)
+    token = validator_with_leeway.authenticate_token(token_string)
+    assert token is not None


### PR DESCRIPTION
<!--
> DO NOT SEND ANY SECURITY FIX HERE. Please read "Security Reporting" section
> on README.
-->

**What kind of change does this PR introduce?**

Bugfix. `JWTBearerTokenValidator` had a hardcoded `leeway=60` in
`authenticate_token`, making clock skew tolerance impossible to configure
without subclassing. Related to #609.


**Checklist**

- [x] The commits follow the [conventional commits](https://www.conventionalcommits.org) specification.
- [ ] You ran the linters with ``prek``.
- [x] You wrote unit test to demonstrate the bug you are fixing, or to stress the feature you are bringing.
- [x] You reached 100% of code coverage on the code you edited, without abusive use of `pragma: no cover`
- [ ] If this PR is about a new feature, or a behavior change, you have updated the documentation accordingly.

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
