### PR TITLE
fix(oauth): cast sub claim to string in JWTBearerTokenGenerator

### DIFF
--- a/authlib/oauth2/rfc9068/token.py
+++ b/authlib/oauth2/rfc9068/token.py
@@ -144,7 +144,7 @@ class JWTBearerTokenGenerator(BearerTokenGenerator):
         # correspond to the subject identifier of the resource owner.
 
         if user:
-            token_data["sub"] = user.get_user_id()
+            token_data["sub"] = str(user.get_user_id())
 
         # In cases of access tokens obtained through grants where no resource owner is
         # involved, such as the client credentials grant, the value of 'sub' SHOULD

--- a/tests/flask/test_oauth2/rfc9068/test_resource_server.py
+++ b/tests/flask/test_oauth2/rfc9068/test_resource_server.py
@@ -129,7 +129,7 @@ def create_access_token_claims(client, user):
         "iss": issuer,
         "exp": expires_in,
         "aud": resource_server,
-        "sub": user.get_user_id(),
+        "sub": str(user.get_user_id()),
         "client_id": client.client_id,
         "iat": now,
         "jti": generate_token(16),

--- a/tests/flask/test_oauth2/rfc9068/test_token_generation.py
+++ b/tests/flask/test_oauth2/rfc9068/test_token_generation.py
@@ -100,7 +100,7 @@ def test_generate_jwt_access_token(test_client, client, user, jwks):
     claims = jwt.decode(access_token, jwks)
 
     assert claims["iss"] == issuer
-    assert claims["sub"] == user.id
+    assert claims["sub"] == str(user.id)
     assert claims["scope"] == client.scope
     assert claims["client_id"] == client.client_id
 

--- a/tests/flask/test_oauth2/rfc9068/test_token_introspection.py
+++ b/tests/flask/test_oauth2/rfc9068/test_token_introspection.py
@@ -96,7 +96,7 @@ def create_access_token_claims(client, user):
         "iss": issuer,
         "exp": expires_in,
         "aud": [resource_server],
-        "sub": user.get_user_id(),
+        "sub": str(user.get_user_id()),
         "client_id": client.client_id,
         "iat": now,
         "jti": generate_token(16),
@@ -140,7 +140,7 @@ def test_introspection(test_client, client, user, access_token):
     assert resp["client_id"] == client.client_id
     assert resp["token_type"] == "Bearer"
     assert resp["scope"] == client.scope
-    assert resp["sub"] == user.id
+    assert resp["sub"] == str(user.id)
     assert resp["aud"] == [resource_server]
     assert resp["iss"] == issuer
 

--- a/tests/flask/test_oauth2/rfc9068/test_token_revocation.py
+++ b/tests/flask/test_oauth2/rfc9068/test_token_revocation.py
@@ -92,7 +92,7 @@ def create_access_token_claims(client, user):
         "iss": issuer,
         "exp": expires_in,
         "aud": [resource_server],
-        "sub": user.get_user_id(),
+        "sub": str(user.get_user_id()),
         "client_id": client.client_id,
         "iat": now,
         "jti": generate_token(16),


### PR DESCRIPTION
**What kind of change does this PR introduce?**

A bugfix for #910. `JWTBearerTokenGenerator.access_token_generator` (RFC 9068) now casts the `sub` claim to `str()` instead of passing `user.get_user_id()` through unchanged. Per RFC 7519 §4.1.2, sub must be a `StringOrURI` (`string`). Authlib's own documented `get_user_id()` example returns an int, so generated tokens were non-compliant, and joserfc 1.7.3's stricter claim validation now rejects them. Existing tests/flask/test_oauth2/rfc9068/ tests updated to assert the corrected string `sub`. The full test suite passes.

**Does this PR introduce a breaking change?**

No. `sub` was already required to be a string per RFC 7519/9068. This fixes non-compliant output, it doesn't change any public API, method signature, or import path.

**Checklist**

- [x] The commits follow the [conventional commits](https://www.conventionalcommits.org) specification.
- [x] You ran the linters with ``prek``.
- [x] You wrote unit test to demonstrate the bug you are fixing, or to stress the feature you are bringing.
- [x] You reached 100% of code coverage on the code you edited, without abusive use of `pragma: no cover`
- [ ] If this PR is about a new feature, or a behavior change, you have updated the documentation accordingly.

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
