### PR TITLE
Ignore unknown kty in import_key_set (RFC 7517 §5)

### DIFF
--- a/authlib/jose/rfc7517/jwk.py
+++ b/authlib/jose/rfc7517/jwk.py
@@ -51,8 +51,16 @@ class JsonWebKey:
         """
         raw = _transform_raw_key(raw)
         if isinstance(raw, dict) and "keys" in raw:
-            keys = raw.get("keys")
-            return KeySet([cls.import_key(k) for k in keys])
+            keys = []
+            for k in raw["keys"]:
+                # RFC 7517, Section 5: ignore a key whose "kty" is not understood
+                # rather than failing the whole set. Matters as post-quantum keys
+                # (e.g. ML-DSA, kty "AKP") start appearing alongside classical ones.
+                kty = k.get("kty") if isinstance(k, dict) else None
+                if kty is not None and kty not in cls.JWK_KEY_CLS:
+                    continue
+                keys.append(cls.import_key(k))
+            return KeySet(keys)
         raise ValueError("Invalid key set format")
 
 

--- a/tests/jose/test_jwk.py
+++ b/tests/jose/test_jwk.py
@@ -273,6 +273,19 @@ def test_jwk_import_key_set():
         JsonWebKey.import_key_set("invalid")
 
 
+def test_jwk_import_key_set_ignores_unknown_kty():
+    # RFC 7517 Section 5: a key whose "kty" is not understood is ignored, not fatal.
+    jwks = {
+        "keys": [
+            {"kty": "AKP", "alg": "ML-DSA-65", "pub": "AAAA", "kid": "pq"},
+            {"kty": "oct", "k": "c2VjcmV0", "kid": "classical"},
+        ]
+    }
+    key_set = JsonWebKey.import_key_set(jwks)
+    assert len(key_set.keys) == 1
+    assert key_set.keys[0].kid == "classical"
+
+
 def test_jwk_find_by_kid_with_use():
     key1 = OctKey.import_key("secret", {"kid": "abc", "use": "sig"})
     key2 = OctKey.import_key("secret", {"kid": "abc", "use": "enc"})


### PR DESCRIPTION
### What

`JsonWebKey.import_key_set()` now skips a key whose `kty` is present but not recognised, instead of raising `KeyError` and failing the whole set.

### Why

Today `import_key_set` does `[cls.import_key(k) for k in keys]`; the first key with an unregistered `kty` raises `KeyError` (e.g. `KeyError: 'AKP'`) and the entire set fails to import. RFC 7517 §5 says a processor SHOULD ignore key types it does not understand.

This is becoming a live problem as post-quantum keys (ML-DSA, `kty:"AKP"`, RFC 9964) begin appearing in published JWKS next to RSA/EC keys: a consumer stops verifying **every** signature from that issuer, including the classical ones, the moment such a key is published. Relates to #913.

### Change

- `import_key_set` skips only keys whose `kty` is explicitly present and not in `JWK_KEY_CLS`; a recognised-but-malformed key still raises as before.
- Added `test_jwk_import_key_set_ignores_unknown_kty`.

`tests/jose/test_jwk.py` passes (26 passed). I know `authlib.jose` is deprecated in favour of joserfc; happy to also PR joserfc (it has the same behaviour), but since `authlib.jose` still ships and is widely used pre-2.0, this keeps it safe in the meantime.