### PR TITLE
fix(jose): ignore unrecognised kty entries in import_key_set

### DIFF
--- a/authlib/jose/rfc7517/jwk.py
+++ b/authlib/jose/rfc7517/jwk.py
@@ -47,12 +47,23 @@ class JsonWebKey:
     def import_key_set(cls, raw):
         """Import KeySet from string, dict or a list of keys.
 
+        Per RFC 7517 Section 5, members of a JWK Set whose ``kty`` is not
+        understood are ignored rather than treated as a fatal error, so a
+        single unsupported key does not prevent the rest of the set from
+        being imported.
+
         :return: KeySet instance
         """
         raw = _transform_raw_key(raw)
         if isinstance(raw, dict) and "keys" in raw:
             keys = raw.get("keys")
-            return KeySet([cls.import_key(k) for k in keys])
+            imported_keys = []
+            for k in keys:
+                kty = k.get("kty") if isinstance(k, dict) else None
+                if kty is not None and kty not in cls.JWK_KEY_CLS:
+                    continue
+                imported_keys.append(cls.import_key(k))
+            return KeySet(imported_keys)
         raise ValueError("Invalid key set format")
 
 

--- a/tests/jose/test_jwk.py
+++ b/tests/jose/test_jwk.py
@@ -273,6 +273,23 @@ def test_jwk_import_key_set():
         JsonWebKey.import_key_set("invalid")
 
 
+def test_jwk_import_key_set_ignores_unknown_kty():
+    # RFC 7517 Section 5: JWKs with an unrecognised "kty" SHOULD be
+    # ignored instead of failing the whole set.
+    jwks_public = read_file_path("jwks_public.json")
+    keys = list(jwks_public["keys"])
+    keys.append({"kty": "AKP", "kid": "pq", "pub": "somevalue"})
+
+    key_set = JsonWebKey.import_key_set({"keys": keys})
+    assert len(key_set.keys) == len(jwks_public["keys"])
+
+    key = key_set.find_by_kid("abc")
+    assert key["e"] == "AQAB"
+
+    with pytest.raises(ValueError):
+        key_set.find_by_kid("pq")
+
+
 def test_jwk_find_by_kid_with_use():
     key1 = OctKey.import_key("secret", {"kid": "abc", "use": "sig"})
     key2 = OctKey.import_key("secret", {"kid": "abc", "use": "enc"})


### PR DESCRIPTION
import_key_set() maps every key through import_key(), which does key_cls = cls.JWK_KEY_CLS[kty]. If one key in the set has a kty Authlib doesn't register, that's a bare KeyError, and the whole set fails to import. Classical RSA/EC keys included, even though they're perfectly fine.

RFC 7517 Section 5 says unrecognised kty members SHOULD be ignored, not fatal. This matters right now because ML-DSA/AKP (RFC 9964) keys are starting to show up in JWKS published by other ecosystems, so a single PQ key in a set can knock out verification for everything else from that issuer.

Fix: in import_key_set, skip a member if its kty isn't in JWK_KEY_CLS instead of calling import_key on it. import_key itself is untouched, so importing a single unknown key directly still raises like before.

Added a regression test in tests/jose/test_jwk.py mixing a known RSA key with a fake AKP key, and confirmed against the repro from the issue (an RSA + EC + AKP set that currently raises KeyError: 'AKP' on main).

Fixes #913