### PR TITLE
Fix RFC7523 malformed claims handling

### DIFF
--- a/authlib/oauth2/rfc7523/client.py
+++ b/authlib/oauth2/rfc7523/client.py
@@ -46,7 +46,15 @@ class JWTBearerClientAssertion:
         assertion = data.get("client_assertion")
         if assertion_type == ASSERTION_TYPE and assertion:
             headers, claims = self.extract_assertion(assertion)
+            # "sub" is read before the signature and the claims are verified,
+            # so it cannot be assumed to be present nor to be a string.
+            if "sub" not in claims:
+                raise InvalidClientError(description="Missing claim: 'sub'")
+
             client_id = claims["sub"]
+            if not isinstance(client_id, str):
+                raise InvalidClientError(description="Invalid claim: 'sub'")
+
             client = query_client(client_id)
             if not client:
                 raise InvalidClientError(
@@ -137,11 +145,20 @@ class JWTBearerClientAssertion:
         )
 
     def extract_assertion(self, assertion: str):
-        obj = jws.extract_compact(to_bytes(assertion))
+        try:
+            obj = jws.extract_compact(to_bytes(assertion))
+        except JoseError as e:
+            log.debug("Assertion Error: %r", e)
+            raise InvalidClientError(description="Invalid JWT assertion.") from e
+
         try:
             claims = json_loads(obj.payload)
         except ValueError:
             raise InvalidClientError(description="Invalid JWT payload.") from None
+
+        if not isinstance(claims, dict):
+            raise InvalidClientError(description="Invalid JWT payload.")
+
         return obj.headers(), claims
 
     def validate_jti(self, claims, jti):

--- a/authlib/oauth2/rfc7523/jwt_bearer.py
+++ b/authlib/oauth2/rfc7523/jwt_bearer.py
@@ -82,7 +82,20 @@ class JWTBearerGrant(BaseGrant, TokenEndpointMixin):
         .. _`Section 3.1`: https://tools.ietf.org/html/rfc7523#section-3.1
         """
         headers, claims = self.extract_assertion(assertion)
-        client = self.resolve_issuer_client(claims["iss"])
+        # "iss" is read before the signature and the claims are verified, so it
+        # cannot be assumed to be present nor to be a string.
+        if "iss" not in claims:
+            raise InvalidGrantError(description="Missing claim: 'iss'")
+
+        issuer = claims["iss"]
+        if not isinstance(issuer, str):
+            raise InvalidGrantError(description="Invalid claim: 'iss'")
+
+        client = self.resolve_issuer_client(issuer)
+        if not client:
+            raise InvalidGrantError(
+                description="The client does not exist on this server."
+            )
 
         if hasattr(self, "resolve_client_key"):  # pragma: no cover
             key = import_any_key(self.resolve_client_key(client, headers, claims))
@@ -106,11 +119,20 @@ class JWTBearerGrant(BaseGrant, TokenEndpointMixin):
         return token.claims
 
     def extract_assertion(self, assertion: str):
-        obj = jws.extract_compact(to_bytes(assertion))
+        try:
+            obj = jws.extract_compact(to_bytes(assertion))
+        except JoseError as e:
+            log.debug("Assertion Error: %r", e)
+            raise InvalidGrantError(description="Invalid JWT assertion.") from e
+
         try:
             claims = json_loads(obj.payload)
         except ValueError:
             raise InvalidGrantError(description="Invalid JWT payload.") from None
+
+        if not isinstance(claims, dict):
+            raise InvalidGrantError(description="Invalid JWT payload.")
+
         return obj.headers(), claims
 
     def validate_token_request(self):
@@ -194,7 +216,8 @@ class JWTBearerGrant(BaseGrant, TokenEndpointMixin):
                 return Client.query_by_iss(issuer)
 
         :param issuer: "iss" value in assertion
-        :return: Client instance
+        :return: Client instance, or ``None`` when no client matches the
+            issuer. In that case an ``invalid_grant`` error is returned.
         """
         raise NotImplementedError()
 

--- a/docs/upgrades/changelog.rst
+++ b/docs/upgrades/changelog.rst
@@ -41,6 +41,10 @@ Version 1.8.0
   ``joserfc`` 1.6.1.
 - Declare lower bounds for the optional integration dependencies and test them
   in CI against their minimum versions with uv's ``lowest-direct`` resolution.
+- The token endpoint answers malformed RFC 7523 assertions with an
+  ``invalid_client`` or ``invalid_grant`` error instead of raising an unhandled
+  exception. ``JWTBearerGrant.resolve_issuer_client()`` may return ``None`` for
+  an unknown issuer.
 
 Version 1.7.2
 -------------

--- a/tests/flask/test_oauth2/test_jwt_bearer_client_auth.py
+++ b/tests/flask/test_oauth2/test_jwt_bearer_client_auth.py
@@ -342,3 +342,94 @@ def test_issuer_as_audience(test_client, server):
     )
     resp = json.loads(rv.data)
     assert "access_token" in resp
+
+
+def test_malformed_assertion(test_client, server):
+    """A 'client_assertion' that is not a compact JWS is rejected with an OAuth
+    error."""
+    register_jwt_client_auth(server)
+    rv = test_client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_assertion_type": JWTBearerClientAssertion.CLIENT_ASSERTION_TYPE,
+            "client_assertion": "not-a-jwt",
+        },
+    )
+    resp = json.loads(rv.data)
+    assert resp["error"] == "invalid_client"
+    assert resp["error_description"] == "Invalid JWT assertion."
+
+
+def test_non_object_payload_assertion(test_client, server):
+    """An assertion payload that is valid JSON but not a JSON object cannot
+    hold claims."""
+    register_jwt_client_auth(server)
+    client_assertion = jws.serialize_compact(
+        {"alg": "HS256"},
+        '["client-id"]',
+        OctKey.import_key("client-secret"),
+    )
+    rv = test_client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_assertion_type": JWTBearerClientAssertion.CLIENT_ASSERTION_TYPE,
+            "client_assertion": client_assertion,
+        },
+    )
+    resp = json.loads(rv.data)
+    assert resp["error"] == "invalid_client"
+    assert resp["error_description"] == "Invalid JWT payload."
+
+
+def test_missing_sub_claim(test_client, server):
+    """The 'sub' claim is read before the claims are verified, so its absence
+    must be reported as an OAuth error."""
+    register_jwt_client_auth(server)
+    claims = {
+        "iss": "client-id",
+        "aud": "https://provider.test/oauth/token",
+        "exp": int(time.time() + 3600),
+        "jti": "nonce",
+    }
+    client_assertion = jwt.encode(
+        {"alg": "HS256"}, claims, OctKey.import_key("client-secret")
+    )
+    rv = test_client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_assertion_type": JWTBearerClientAssertion.CLIENT_ASSERTION_TYPE,
+            "client_assertion": client_assertion,
+        },
+    )
+    resp = json.loads(rv.data)
+    assert resp["error"] == "invalid_client"
+    assert resp["error_description"] == "Missing claim: 'sub'"
+
+
+def test_non_string_sub_claim(test_client, server):
+    """A non-string 'sub' claim must not reach 'query_client'."""
+    register_jwt_client_auth(server)
+    claims = {
+        "iss": "client-id",
+        "sub": {"client_id": "client-id"},
+        "aud": "https://provider.test/oauth/token",
+        "exp": int(time.time() + 3600),
+        "jti": "nonce",
+    }
+    client_assertion = jwt.encode(
+        {"alg": "HS256"}, claims, OctKey.import_key("client-secret")
+    )
+    rv = test_client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_assertion_type": JWTBearerClientAssertion.CLIENT_ASSERTION_TYPE,
+            "client_assertion": client_assertion,
+        },
+    )
+    resp = json.loads(rv.data)
+    assert resp["error"] == "invalid_client"
+    assert resp["error_description"] == "Invalid claim: 'sub'"

--- a/tests/flask/test_oauth2/test_jwt_bearer_grant.py
+++ b/tests/flask/test_oauth2/test_jwt_bearer_grant.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 from flask import json
 from joserfc import jws
@@ -229,3 +231,88 @@ def test_invalid_audience(test_client, server):
     )
     resp = json.loads(rv.data)
     assert resp["error"] == "invalid_grant"
+
+
+def test_malformed_assertion(test_client):
+    """An 'assertion' that is not a compact JWS is rejected with an OAuth
+    error."""
+    rv = test_client.post(
+        "/oauth/token",
+        data={"grant_type": JWTBearerGrant.GRANT_TYPE, "assertion": "not-a-jwt"},
+    )
+    resp = json.loads(rv.data)
+    assert resp["error"] == "invalid_grant"
+    assert resp["error_description"] == "Invalid JWT assertion."
+
+
+def test_non_object_payload_assertion(test_client):
+    """An assertion payload that is valid JSON but not a JSON object cannot
+    hold claims."""
+    assertion = jws.serialize_compact(
+        {"alg": "HS256", "kid": "1"},
+        '["client-id"]',
+        OctKey.import_key("foo"),
+    )
+    rv = test_client.post(
+        "/oauth/token",
+        data={"grant_type": JWTBearerGrant.GRANT_TYPE, "assertion": assertion},
+    )
+    resp = json.loads(rv.data)
+    assert resp["error"] == "invalid_grant"
+    assert resp["error_description"] == "Invalid JWT payload."
+
+
+def test_missing_iss_claim(test_client):
+    """The 'iss' claim is read before the claims are verified, so its absence
+    must be reported as an OAuth error."""
+    assertion = jwt.encode(
+        {"alg": "HS256", "kid": "1"},
+        {"aud": "https://provider.test/token", "exp": int(time.time() + 3600)},
+        OctKey.import_key("foo"),
+    )
+    rv = test_client.post(
+        "/oauth/token",
+        data={"grant_type": JWTBearerGrant.GRANT_TYPE, "assertion": assertion},
+    )
+    resp = json.loads(rv.data)
+    assert resp["error"] == "invalid_grant"
+    assert resp["error_description"] == "Missing claim: 'iss'"
+
+
+def test_non_string_iss_claim(test_client):
+    """A non-string 'iss' claim must not reach 'resolve_issuer_client'."""
+    assertion = jwt.encode(
+        {"alg": "HS256", "kid": "1"},
+        {
+            "iss": ["client-id"],
+            "aud": "https://provider.test/token",
+            "exp": int(time.time() + 3600),
+        },
+        OctKey.import_key("foo"),
+    )
+    rv = test_client.post(
+        "/oauth/token",
+        data={"grant_type": JWTBearerGrant.GRANT_TYPE, "assertion": assertion},
+    )
+    resp = json.loads(rv.data)
+    assert resp["error"] == "invalid_grant"
+    assert resp["error_description"] == "Invalid claim: 'iss'"
+
+
+def test_unknown_issuer(test_client):
+    """'resolve_issuer_client' returning None yields an 'invalid_grant'
+    error."""
+    assertion = JWTBearerGrant.sign(
+        "foo",
+        issuer="unknown-client",
+        audience="https://provider.test/token",
+        subject=None,
+        header={"alg": "HS256", "kid": "1"},
+    )
+    rv = test_client.post(
+        "/oauth/token",
+        data={"grant_type": JWTBearerGrant.GRANT_TYPE, "assertion": assertion},
+    )
+    resp = json.loads(rv.data)
+    assert resp["error"] == "invalid_grant"
+    assert resp["error_description"] == "The client does not exist on this server."


### PR DESCRIPTION
- Malformed RFC7523 assertions now raise correct Authlib exceptions
- `resolve_issuer_client` can return None, and Authlib makes it a `InvalidGrantError`


- [x] The commits follow the [conventional commits](https://www.conventionalcommits.org) specification.
- [x] You ran the linters with ``prek``.
- [x] You wrote unit test to demonstrate the bug you are fixing, or to stress the feature you are bringing.
- [x] You reached 100% of code coverage on the code you edited, without abusive use of `pragma: no cover`
- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
